### PR TITLE
docs: add AGENTS.md and agent-guidelines documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+This file defines baseline instructions for coding agents working in this repository.
+
+## Scope
+- This file applies to the entire repository unless overridden by a deeper `AGENTS.md`.
+- Detailed policies live in `docs/agent-guidelines/`.
+
+## Instruction Priority
+1. System / developer / user instructions in the active session.
+2. `AGENTS.md` files (nearest file in the directory tree wins).
+3. Documents in `docs/agent-guidelines/`.
+
+## Working Agreement
+- Keep changes focused on the requested task.
+- Prefer small, atomic commits.
+- Run relevant tests/linters before finishing.
+- If behavior or contracts are changed, update documentation.
+
+## Required Reading
+Before implementing significant changes, review:
+- `docs/agent-guidelines/README.md`
+- `docs/agent-guidelines/coding-style.md`
+- `docs/agent-guidelines/testing.md`
+- `docs/agent-guidelines/commits.md`
+- `docs/agent-guidelines/security.md`

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ You can interact with the API via Swagger UI once the application is running. Th
 * [ ] Add full React-based frontend for interacting with content
 * [ ] Deploy using Docker and CI/CD pipeline
 
+
+## Agent Collaboration
+
+The repository includes agent-focused instructions in:
+
+- `AGENTS.md`
+- `docs/agent-guidelines/README.md`
+- `docs/agent-guidelines/coding-style.md`
+- `docs/agent-guidelines/testing.md`
+- `docs/agent-guidelines/commits.md`
+- `docs/agent-guidelines/security.md`
+
+These documents define universal development, testing, commit, and security expectations for both human contributors and coding agents.
+
 ## Contributing
 
 Contributions are welcome! Please open issues or pull requests to help improve the project.

--- a/docs/agent-guidelines/README.md
+++ b/docs/agent-guidelines/README.md
@@ -1,0 +1,25 @@
+# Agent Guidelines
+
+This folder contains universal engineering instructions that can be followed by both humans and coding agents.
+
+## Documents
+- `coding-style.md` — conventions for naming, structure, formatting, and maintainability.
+- `testing.md` — testing strategy, test quality bar, and execution rules.
+- `commits.md` — commit message standard and change-set hygiene.
+- `security.md` — secure coding rules and review checklist.
+
+## How to use
+1. Read this file first.
+2. Apply relevant rules from each topic-specific document.
+3. If rules conflict, prefer:
+   - explicit task instructions,
+   - then `AGENTS.md`,
+   - then these topic documents.
+
+## Definition of Done (DoD)
+A change is done when:
+- code follows style conventions,
+- tests are added/updated and pass,
+- no avoidable security regressions are introduced,
+- commit history is clear and conventional,
+- docs are updated when behavior changes.

--- a/docs/agent-guidelines/coding-style.md
+++ b/docs/agent-guidelines/coding-style.md
@@ -1,0 +1,32 @@
+# Coding Style
+
+## Core principles
+- Prefer readability over cleverness.
+- Keep functions/classes small and single-purpose.
+- Avoid hidden side effects.
+- Use explicit names that communicate intent.
+
+## Naming
+- Use consistent language across the repository (English for code symbols).
+- Names should describe domain meaning, not implementation details.
+- Avoid abbreviations unless they are established and unambiguous.
+
+## Structure
+- Keep modules cohesive and low-coupled.
+- Organize code by domain responsibility.
+- Avoid circular dependencies.
+
+## Error handling
+- Fail fast on invalid input.
+- Return actionable error messages.
+- Do not swallow exceptions silently.
+
+## Comments and docs
+- Comment _why_, not _what_ (when code is already clear).
+- Keep public contracts documented (API/DTO/events).
+- Remove outdated comments in the same change.
+
+## Clean code checklist
+- No dead code or commented-out blocks.
+- No TODOs without an issue/task reference.
+- No unrelated refactors in task-specific changes.

--- a/docs/agent-guidelines/commits.md
+++ b/docs/agent-guidelines/commits.md
@@ -1,0 +1,29 @@
+# Commit Guidelines
+
+## Format
+Use Conventional Commits:
+- `feat:` new functionality
+- `fix:` bug fixes
+- `refactor:` internal restructuring without behavior change
+- `test:` tests only
+- `docs:` documentation only
+- `chore:` maintenance/tooling
+
+Examples:
+- `docs: add baseline AGENTS and agent guidelines`
+- `fix(api): validate node parent before update`
+
+## Scope and size
+- Keep commits atomic and logically grouped.
+- One commit should represent one coherent intent.
+- Avoid mixing formatting-only changes with functional changes.
+
+## Message quality
+- Use imperative mood ("add", "update", "remove").
+- Explain _what_ changed; optionally include _why_ if not obvious.
+- Reference issue/task IDs when available.
+
+## Pre-commit checklist
+- Relevant tests pass.
+- No secrets or credentials included.
+- No generated noise files unless required.

--- a/docs/agent-guidelines/security.md
+++ b/docs/agent-guidelines/security.md
@@ -1,0 +1,31 @@
+# Security Guidelines
+
+## Secrets and credentials
+- Never hardcode secrets, tokens, passwords, or private keys.
+- Use environment variables or secret managers.
+- Do not commit `.env` files with real values.
+
+## Input and validation
+- Treat all external input as untrusted.
+- Validate and sanitize input at system boundaries.
+- Enforce allowlists where possible.
+
+## Authentication and authorization
+- Enforce authentication before sensitive operations.
+- Check authorization at the business action level, not only at routing level.
+- Follow least-privilege principles for service accounts and API keys.
+
+## Data protection
+- Avoid storing sensitive data unless necessary.
+- Mask sensitive fields in logs.
+- Use transport encryption (HTTPS/TLS) for external communication.
+
+## Dependency hygiene
+- Prefer well-maintained dependencies.
+- Avoid adding dependencies for trivial utilities.
+- Track and patch known vulnerabilities.
+
+## Security review checklist
+- No secret leaks in code, config, logs, or tests.
+- No new unsafe deserialization or dynamic code execution paths.
+- Errors do not expose internal implementation details.

--- a/docs/agent-guidelines/testing.md
+++ b/docs/agent-guidelines/testing.md
@@ -1,0 +1,27 @@
+# Testing Guidelines
+
+## Testing strategy
+- Follow a practical test pyramid:
+  - unit tests for domain logic,
+  - integration tests for boundaries (DB, API, messaging),
+  - end-to-end tests for critical user flows.
+- Add or update tests for every behavior change.
+
+## Test quality
+- Tests must be deterministic and isolated.
+- Prefer real behavior over over-mocking.
+- Assert observable outcomes, not internal implementation details.
+
+## Naming and layout
+- Test names should describe scenario + expected behavior.
+- Arrange tests with clear Given / When / Then structure.
+- Keep fixtures minimal and reusable.
+
+## Coverage expectations
+- Cover happy paths, edge cases, and at least one failure path.
+- For bug fixes, include a regression test.
+
+## Execution
+- Run only affected test suites during iteration for speed.
+- Run broader checks before finalizing the change.
+- If a test cannot be run due to environment limits, document it explicitly.


### PR DESCRIPTION
### Motivation
- Provide a single repository-level entry point and priority rules for coding agents and human contributors via `AGENTS.md`. 
- Centralize core engineering policies (coding style, testing, commit messages, security) into `docs/agent-guidelines/` to reduce onboarding friction and ensure consistent contributions. 
- Update the project `README.md` to advertise these guidelines and the repository's agent collaboration model.

### Description
- Add root `AGENTS.md` that defines scope, instruction priority, working agreements, and required reading. 
- Add `docs/agent-guidelines/README.md` as an index and DoD for agent-driven changes. 
- Add focused guideline files: `docs/agent-guidelines/coding-style.md`, `docs/agent-guidelines/testing.md`, `docs/agent-guidelines/commits.md`, and `docs/agent-guidelines/security.md`. 
- Update `README.md` to include an "Agent Collaboration" section linking the new documents.

### Testing
- Ran `git diff --check` and it reported no whitespace or diff issues. 
- Verified working tree with `git status --short` to confirm staged and new files. 
- Created a commit with message `docs: add AGENTS and core agent guideline docs` which recorded the additions successfully.
