### PR TITLE
feat: add public admin MVP for wiki data management

### DIFF
--- a/WikiWeaver.MinimalApi/Endpoints/AdminEndpoints.cs
+++ b/WikiWeaver.MinimalApi/Endpoints/AdminEndpoints.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using WikiWeaver.Infrastructure.Data;
+
+namespace WikiWeaver.MinimalApi.Endpoints;
+
+public static class AdminEndpoints
+{
+    public static IEndpointRouteBuilder MapAdminEndpoints(this IEndpointRouteBuilder builder)
+    {
+        var group = builder.MapGroup("/admin").WithTags("Admin");
+
+        group.MapPost("/cleanup", async (WikiWeaverDbContext dbContext, ILoggerFactory loggerFactory) =>
+        {
+            var logger = loggerFactory.CreateLogger("AdminCleanup");
+
+            var nodeCount = await dbContext.Nodes.CountAsync();
+            var articleCount = await dbContext.Articles.CountAsync();
+            var paragraphCount = await dbContext.Paragraphs.CountAsync();
+
+            await using var transaction = await dbContext.Database.BeginTransactionAsync();
+
+            await dbContext.Database.ExecuteSqlRawAsync(
+                "TRUNCATE TABLE \"Paragraphs\", \"Articles\", \"Nodes\" RESTART IDENTITY CASCADE;");
+
+            await transaction.CommitAsync();
+
+            logger.LogWarning(
+                "Public admin cleanup executed. Deleted Nodes: {NodeCount}, Articles: {ArticleCount}, Paragraphs: {ParagraphCount}",
+                nodeCount,
+                articleCount,
+                paragraphCount);
+
+            return Results.Ok(new
+            {
+                deletedNodes = nodeCount,
+                deletedArticles = articleCount,
+                deletedParagraphs = paragraphCount,
+                message = "Cleanup completed"
+            });
+        });
+
+        return builder;
+    }
+}

--- a/WikiWeaver.MinimalApi/Program.cs
+++ b/WikiWeaver.MinimalApi/Program.cs
@@ -62,10 +62,9 @@ app.UseCors("AllowWikiWeaverReact");
 
 app.MapArticleContentEndpoints();
 app.MapNavigationEndpoints();
-// TODO: will activate after MVP
-//app.MapNodeEndpoints();
-//app.MapArticleEndpoints();
-//app.MapParagraphEndpoints();
+app.MapNodeEndpoints();
+app.MapArticleEndpoints();
+app.MapParagraphEndpoints();
+app.MapAdminEndpoints();
 
 app.Run();
-

--- a/docs/admin-mvp-plan.md
+++ b/docs/admin-mvp-plan.md
@@ -1,0 +1,19 @@
+# Admin Panel MVP Plan
+
+## Current scope implemented
+- Public `/admin` page (temporary for MVP).
+- Lists for nodes, articles, paragraphs.
+- Deletion actions for nodes, articles, paragraphs.
+- Dangerous maintenance action to delete all nodes/articles/paragraphs (`POST /admin/cleanup`).
+
+## Explicit limitations
+- No authentication/authorization yet.
+- No hide/unhide operation yet.
+- No move operation in navigation tree yet.
+
+## Next iteration tasks
+1. Add authentication and role-based access control for all `/admin` endpoints and UI routes.
+2. Add node move operation with cycle-prevention validation.
+3. Add hide/unhide flags for nodes and articles and expose them in navigation.
+4. Add audit log storage for destructive actions.
+5. Add integration tests that verify permissions, delete behavior, and cleanup safety checks.

--- a/wikiweaver.react/src/app/App.tsx
+++ b/wikiweaver.react/src/app/App.tsx
@@ -5,6 +5,7 @@ import { customTheme } from '../theme/themeConfig';
 import MainLayout from '../layouts/MainLayout';
 import WelcomePage from '../pages/WelcomePage';
 import ArticlePage from '../pages/ArticlePage';
+import AdminPage from '../pages/AdminPage';
 
 // Создаем экземпляр QueryClient
 const queryClient = new QueryClient();
@@ -18,6 +19,7 @@ function App() {
             <Routes>
               <Route path="/" element={<WelcomePage />} />
               <Route path="/article/:id" element={<ArticlePage />} />
+              <Route path="/admin" element={<AdminPage />} />
             </Routes>
           </MainLayout>
         </Router>

--- a/wikiweaver.react/src/layouts/MainLayout.module.css
+++ b/wikiweaver.react/src/layouts/MainLayout.module.css
@@ -11,13 +11,13 @@
   justify-content: space-between;
   background: #ffffff;
   width: 100%;
-  height: 64px; /* APP_CONSTANTS.DIMENSIONS.HEADER_HEIGHT */
+  height: 64px;
 }
 
 .headerBrandSection {
   display: flex;
   align-items: center;
-  width: 300px; /* APP_CONSTANTS.DIMENSIONS.SIDEBAR_WIDTH */
+  width: 300px;
   border-right: 2px solid #d9d9d9;
   border-bottom: 2px solid #d9d9d9;
 }
@@ -26,21 +26,31 @@
   color: #000000;
   padding-inline: 20px;
   font-size: 24px;
-  width: 300px; /* APP_CONSTANTS.DIMENSIONS.SIDEBAR_WIDTH */
+  width: 300px;
   text-decoration: none;
 }
 
 .headerBrandLink h1 {
   margin: 0;
   font-size: 24px;
-  line-height: 64px; /* APP_CONSTANTS.DIMENSIONS.HEADER_HEIGHT */
+  line-height: 64px;
+}
+
+.headerActions {
+  padding-inline: 20px;
+}
+
+.adminLink {
+  color: #1677ff;
+  font-weight: 600;
+  text-decoration: none;
 }
 
 .content {
-  padding: 24px; /* APP_CONSTANTS.MARGINS.CONTENT */
+  padding: 24px;
   background: #ffffff;
   border-radius: 6px;
-  min-height: calc(100vh - 32px - 32px - 64px); /* Вычесть высоту header, margin и padding */
+  min-height: calc(100vh - 32px - 32px - 64px);
 }
 
 .contentWrapper {

--- a/wikiweaver.react/src/layouts/MainLayout.tsx
+++ b/wikiweaver.react/src/layouts/MainLayout.tsx
@@ -21,6 +21,9 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
                         <h1>{APP_CONSTANTS.APP_NAME}</h1>
                     </Link>
                 </div>
+                <div className={styles.headerActions}>
+                    <Link to="/admin" className={styles.adminLink}>Admin panel</Link>
+                </div>
             </Header>
             <Layout hasSider>
                 <Sidebar />

--- a/wikiweaver.react/src/pages/AdminPage.tsx
+++ b/wikiweaver.react/src/pages/AdminPage.tsx
@@ -1,0 +1,310 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Input,
+  Modal,
+  Popconfirm,
+  Space,
+  Table,
+  Tabs,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  cleanupDemoData,
+  deleteArticle,
+  deleteNode,
+  deleteParagraph,
+  getArticles,
+  getNodes,
+  getParagraphs,
+} from '../services/adminService';
+import type { AdminNodeDto, ArticleReadDto, ParagraphReadDto } from '../shared/types/ApiTypes';
+
+const { Title, Text } = Typography;
+
+const CONFIRMATION_PHRASE = 'DELETE DEMO DATA';
+
+const AdminPage: React.FC = () => {
+  const queryClient = useQueryClient();
+  const [messageApi, contextHolder] = message.useMessage();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isCleanupModalOpen, setIsCleanupModalOpen] = useState(false);
+  const [cleanupConfirmation, setCleanupConfirmation] = useState('');
+
+  const nodesQuery = useQuery({ queryKey: ['admin', 'nodes'], queryFn: getNodes });
+  const articlesQuery = useQuery({ queryKey: ['admin', 'articles'], queryFn: getArticles });
+  const paragraphsQuery = useQuery({ queryKey: ['admin', 'paragraphs'], queryFn: getParagraphs });
+
+  const refreshAll = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['admin', 'nodes'] }),
+      queryClient.invalidateQueries({ queryKey: ['admin', 'articles'] }),
+      queryClient.invalidateQueries({ queryKey: ['admin', 'paragraphs'] }),
+      queryClient.invalidateQueries({ queryKey: ['navigationTree'] }),
+    ]);
+  };
+
+  const nodeDeleteMutation = useMutation({
+    mutationFn: deleteNode,
+    onSuccess: async () => {
+      messageApi.success('Node deleted');
+      await refreshAll();
+    },
+    onError: (error) => messageApi.error(`Failed to delete node: ${(error as Error).message}`),
+  });
+
+  const articleDeleteMutation = useMutation({
+    mutationFn: deleteArticle,
+    onSuccess: async () => {
+      messageApi.success('Article deleted');
+      await refreshAll();
+    },
+    onError: (error) => messageApi.error(`Failed to delete article: ${(error as Error).message}`),
+  });
+
+  const paragraphDeleteMutation = useMutation({
+    mutationFn: deleteParagraph,
+    onSuccess: async () => {
+      messageApi.success('Paragraph deleted');
+      await refreshAll();
+    },
+    onError: (error) => messageApi.error(`Failed to delete paragraph: ${(error as Error).message}`),
+  });
+
+  const cleanupMutation = useMutation({
+    mutationFn: cleanupDemoData,
+    onSuccess: async (result) => {
+      messageApi.success(
+        `Cleanup completed. Deleted ${result.deletedNodes} nodes, ${result.deletedArticles} articles and ${result.deletedParagraphs} paragraphs.`,
+      );
+      setCleanupConfirmation('');
+      setIsCleanupModalOpen(false);
+      await refreshAll();
+    },
+    onError: (error) => messageApi.error(`Failed to cleanup demo data: ${(error as Error).message}`),
+  });
+
+  const filteredNodes = useMemo(
+    () =>
+      (nodesQuery.data ?? []).filter((node) =>
+        [node.id.toString(), node.title, node.parentId?.toString() ?? '']
+          .join(' ')
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase()),
+      ),
+    [nodesQuery.data, searchTerm],
+  );
+
+  const filteredArticles = useMemo(
+    () =>
+      (articlesQuery.data ?? []).filter((article) =>
+        [article.id.toString(), article.title, article.nodeId?.toString() ?? '']
+          .join(' ')
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase()),
+      ),
+    [articlesQuery.data, searchTerm],
+  );
+
+  const filteredParagraphs = useMemo(
+    () =>
+      (paragraphsQuery.data ?? []).filter((paragraph) =>
+        [paragraph.id.toString(), paragraph.articleId.toString(), paragraph.content]
+          .join(' ')
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase()),
+      ),
+    [paragraphsQuery.data, searchTerm],
+  );
+
+  const nodeColumns: ColumnsType<AdminNodeDto> = [
+    { title: 'ID', dataIndex: 'id', key: 'id', width: 90 },
+    { title: 'Title', dataIndex: 'title', key: 'title' },
+    {
+      title: 'Parent ID',
+      dataIndex: 'parentId',
+      key: 'parentId',
+      width: 120,
+      render: (parentId: number | null) => parentId ?? <Tag>root</Tag>,
+    },
+    {
+      title: 'Actions',
+      key: 'actions',
+      width: 130,
+      render: (_, record) => (
+        <Popconfirm
+          title="Delete node"
+          description={`Delete node \"${record.title}\"?`}
+          okText="Delete"
+          okButtonProps={{ danger: true }}
+          onConfirm={() => nodeDeleteMutation.mutate(record.id)}
+        >
+          <Button danger size="small">Delete</Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  const articleColumns: ColumnsType<ArticleReadDto> = [
+    { title: 'ID', dataIndex: 'id', key: 'id', width: 90 },
+    { title: 'Title', dataIndex: 'title', key: 'title' },
+    { title: 'Node ID', dataIndex: 'nodeId', key: 'nodeId', width: 120 },
+    {
+      title: 'Actions',
+      key: 'actions',
+      width: 130,
+      render: (_, record) => (
+        <Popconfirm
+          title="Delete article"
+          description={`Delete article \"${record.title}\"?`}
+          okText="Delete"
+          okButtonProps={{ danger: true }}
+          onConfirm={() => articleDeleteMutation.mutate(record.id)}
+        >
+          <Button danger size="small">Delete</Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  const paragraphColumns: ColumnsType<ParagraphReadDto> = [
+    { title: 'ID', dataIndex: 'id', key: 'id', width: 90 },
+    { title: 'Article ID', dataIndex: 'articleId', key: 'articleId', width: 120 },
+    { title: 'Order', dataIndex: 'order', key: 'order', width: 90 },
+    {
+      title: 'Content',
+      dataIndex: 'content',
+      key: 'content',
+      render: (content: string) => <Text ellipsis={{ tooltip: content }}>{content}</Text>,
+    },
+    {
+      title: 'Actions',
+      key: 'actions',
+      width: 130,
+      render: (_, record) => (
+        <Popconfirm
+          title="Delete paragraph"
+          description={`Delete paragraph #${record.id}?`}
+          okText="Delete"
+          okButtonProps={{ danger: true }}
+          onConfirm={() => paragraphDeleteMutation.mutate(record.id)}
+        >
+          <Button danger size="small">Delete</Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      {contextHolder}
+      <Title level={2}>Admin panel (MVP)</Title>
+      <Alert
+        type="warning"
+        showIcon
+        message="Temporary open access"
+        description="This admin panel is currently public for MVP. Access restrictions (authentication/roles) must be added in the next iteration."
+      />
+
+      <Input.Search
+        allowClear
+        placeholder="Search by id/title/content"
+        value={searchTerm}
+        onChange={(event) => setSearchTerm(event.target.value)}
+      />
+
+      <Tabs
+        defaultActiveKey="nodes"
+        items={[
+          {
+            key: 'nodes',
+            label: `Nodes (${filteredNodes.length})`,
+            children: (
+              <Table
+                loading={nodesQuery.isLoading}
+                columns={nodeColumns}
+                dataSource={filteredNodes}
+                rowKey="id"
+                pagination={{ pageSize: 10 }}
+              />
+            ),
+          },
+          {
+            key: 'articles',
+            label: `Articles (${filteredArticles.length})`,
+            children: (
+              <Table
+                loading={articlesQuery.isLoading}
+                columns={articleColumns}
+                dataSource={filteredArticles}
+                rowKey="id"
+                pagination={{ pageSize: 10 }}
+              />
+            ),
+          },
+          {
+            key: 'paragraphs',
+            label: `Paragraphs (${filteredParagraphs.length})`,
+            children: (
+              <Table
+                loading={paragraphsQuery.isLoading}
+                columns={paragraphColumns}
+                dataSource={filteredParagraphs}
+                rowKey="id"
+                pagination={{ pageSize: 10 }}
+              />
+            ),
+          },
+          {
+            key: 'tools',
+            label: 'Tools',
+            children: (
+              <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+                <Alert
+                  type="error"
+                  showIcon
+                  message="Danger zone"
+                  description="Use this only to reset demo data. This action deletes all nodes, articles and paragraphs."
+                />
+                <Button danger type="primary" onClick={() => setIsCleanupModalOpen(true)}>
+                  Delete all nodes and articles
+                </Button>
+              </Space>
+            ),
+          },
+        ]}
+      />
+
+      <Modal
+        title="Delete all demo data"
+        open={isCleanupModalOpen}
+        onCancel={() => setIsCleanupModalOpen(false)}
+        onOk={() => cleanupMutation.mutate()}
+        okButtonProps={{
+          danger: true,
+          disabled: cleanupConfirmation !== CONFIRMATION_PHRASE,
+          loading: cleanupMutation.isPending,
+        }}
+        okText="Delete everything"
+      >
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Text>
+            Type <Text code>{CONFIRMATION_PHRASE}</Text> to confirm that you want to permanently delete all nodes, articles and paragraphs.
+          </Text>
+          <Input
+            value={cleanupConfirmation}
+            onChange={(event) => setCleanupConfirmation(event.target.value)}
+            placeholder={CONFIRMATION_PHRASE}
+          />
+        </Space>
+      </Modal>
+    </Space>
+  );
+};
+
+export default AdminPage;

--- a/wikiweaver.react/src/services/adminService.ts
+++ b/wikiweaver.react/src/services/adminService.ts
@@ -1,0 +1,34 @@
+import apiClient from '../shared/api-client/ApiClient';
+import type { AdminCleanupResultDto, AdminNodeDto, ArticleReadDto, ParagraphReadDto } from '../shared/types/ApiTypes';
+
+export const getNodes = async (): Promise<AdminNodeDto[]> => {
+  const response = await apiClient.get<AdminNodeDto[]>('/nodes');
+  return response.data;
+};
+
+export const getArticles = async (): Promise<ArticleReadDto[]> => {
+  const response = await apiClient.get<ArticleReadDto[]>('/article');
+  return response.data;
+};
+
+export const getParagraphs = async (): Promise<ParagraphReadDto[]> => {
+  const response = await apiClient.get<ParagraphReadDto[]>('/paragraph');
+  return response.data;
+};
+
+export const deleteNode = async (id: number): Promise<void> => {
+  await apiClient.delete(`/nodes/${id}`);
+};
+
+export const deleteArticle = async (id: number): Promise<void> => {
+  await apiClient.delete(`/article/${id}`);
+};
+
+export const deleteParagraph = async (id: number): Promise<void> => {
+  await apiClient.delete(`/paragraph/${id}`);
+};
+
+export const cleanupDemoData = async (): Promise<AdminCleanupResultDto> => {
+  const response = await apiClient.post<AdminCleanupResultDto>('/admin/cleanup');
+  return response.data;
+};

--- a/wikiweaver.react/src/shared/types/ApiTypes.ts
+++ b/wikiweaver.react/src/shared/types/ApiTypes.ts
@@ -21,6 +21,27 @@ export interface ArticleReadDto {
   nodeId?: number;
 }
 
+export interface ParagraphReadDto {
+  id: number;
+  content: string;
+  articleId: number;
+  order: number;
+  isDefault: boolean;
+}
+
+export interface AdminNodeDto {
+  id: number;
+  title: string;
+  parentId: number | null;
+}
+
+export interface AdminCleanupResultDto {
+  deletedNodes: number;
+  deletedArticles: number;
+  deletedParagraphs: number;
+  message: string;
+}
+
 // Type for a navigation tree node
 export interface NavigationNodeDto {
   id: number;

--- a/wikiweaver.react/src/theme/themeConfig.ts
+++ b/wikiweaver.react/src/theme/themeConfig.ts
@@ -1,5 +1,3 @@
-import { theme } from 'antd';
-
 export const customTheme = {
   token: {
     colorBgContainer: '#ffffff', // White background for containers


### PR DESCRIPTION
### Motivation
- Provide a lightweight, operator-facing admin UI and API to manage demo wiki content and to support resetting local/dev demo data quickly.
- Surface node/article/paragraph CRUD endpoints so the admin UI and operator tooling can list and delete content.
- Ship a minimal MVP that is explicitly public for development ease while documenting the required hardening steps for the next iteration.

### Description
- Add `WikiWeaver.MinimalApi/Endpoints/AdminEndpoints.cs` with a transactional `POST /admin/cleanup` that runs `TRUNCATE TABLE "Paragraphs", "Articles", "Nodes" RESTART IDENTITY CASCADE;`, returns deleted counts and writes a warning log.
- Enable endpoint mappings in `Program.cs` by registering node/article/paragraph endpoints and the new `MapAdminEndpoints()` so the admin UI can call the APIs.
- Add the React admin UI including `wikiweaver.react/src/pages/AdminPage.tsx`, the client `wikiweaver.react/src/services/adminService.ts`, and new DTOs in `wikiweaver.react/src/shared/types/ApiTypes.ts`, plus a route at `/admin` in `App.tsx` and an `Admin panel` link in `MainLayout`.
- Add `docs/admin-mvp-plan.md` describing scope and next-step security tasks, and fix a TypeScript build blocker by removing an unused import in `wikiweaver.react/src/theme/themeConfig.ts`.

### Testing
- Ran `npm run build` in `wikiweaver.react` and the frontend build completed successfully (Vite produced production artifacts).
- Started the dev server (`npm run dev`) and ran an automated Playwright script to load `/admin` and capture a screenshot, which succeeded and produced an artifact.
- Attempted `dotnet build WikiWeaver.sln` but it could not run in this environment because the `dotnet` CLI is not installed (tooling failure, not code failure).

------