### PR TITLE
feat(ui+api): convert arrows mode to carousel & add Paragraph `isDefault` handling

### DIFF
--- a/WikiWeaver.Application/DTOs/ParagraphDTOs.cs
+++ b/WikiWeaver.Application/DTOs/ParagraphDTOs.cs
@@ -1,6 +1,6 @@
 ﻿namespace WikiWeaver.Application.DTOs
 {
-    public record ParagraphDto(int Id, string Content, int Order);
+    public record ParagraphDto(int Id, string Content, int Order, bool IsDefault);
 
     public class ParagraphReadDto
     {

--- a/WikiWeaver.Application/Services/ArticleContentService.cs
+++ b/WikiWeaver.Application/Services/ArticleContentService.cs
@@ -29,7 +29,7 @@ namespace WikiWeaver.Application.Services
             var paragraphs = await _paragraphRepo.GetParagraphsByArticleAsync(articleId);
             var paragraphDtos = paragraphs
                 .OrderBy(p => p.Order)
-                .Select(p => new ParagraphDto(p.Id, p.Content, p.Order))
+                .Select(p => new ParagraphDto(p.Id, p.Content, p.Order, p.IsDefault))
                 .ToList();
 
             return new ArticleContentDto(article.Id, article.Title, paragraphDtos);
@@ -80,10 +80,19 @@ namespace WikiWeaver.Application.Services
             var orders = paragraphs.Select(p => p.Order).ToList();
             if (orders.Any(o => o < 1))
                 return (false, "Order must be >= 1.");
-            if (orders.Distinct().Count() != orders.Count)
-                return (false, "Order values must be unique.");
-            if (orders.Count != (orders.Any() ? orders.Max() : 0))
+
+            var distinctOrders = orders.Distinct().OrderBy(o => o).ToList();
+            if (distinctOrders.Count != (distinctOrders.Any() ? distinctOrders.Max() : 0))
                 return (false, "Order values must form a contiguous sequence from 1 to N.");
+
+            var defaultOrders = paragraphs
+                .Where(p => p.IsDefault)
+                .Select(p => p.Order)
+                .ToHashSet();
+
+            if (distinctOrders.Any(order => !defaultOrders.Contains(order)))
+                return (false, "Each order must contain one default paragraph.");
+
             return (true, null);
         }
 
@@ -109,6 +118,7 @@ namespace WikiWeaver.Application.Services
                 var entity = existingMap[incoming.Id];
                 entity.Content = incoming.Content;
                 entity.Order = incoming.Order;
+                entity.IsDefault = incoming.IsDefault;
             }
         }
 
@@ -120,7 +130,7 @@ namespace WikiWeaver.Application.Services
                 {
                     Content = incoming.Content,
                     Order = incoming.Order,
-                    IsDefault = true,
+                    IsDefault = incoming.IsDefault,
                     ArticleId = articleId
                 };
                 await _paragraphRepo.AddAsync(newParagraph);

--- a/wikiweaver.react/src/pages/ArticlePage.tsx
+++ b/wikiweaver.react/src/pages/ArticlePage.tsx
@@ -1,23 +1,54 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getArticleContentById } from '../services/Article/articleService';
-import { Typography, Spin, Alert, Empty } from 'antd';
-import { LoadingOutlined } from '@ant-design/icons';
+import { Typography, Spin, Alert, Empty, Button, Space, Segmented, Tag } from 'antd';
+import { LoadingOutlined, LeftOutlined, RightOutlined } from '@ant-design/icons';
 import { APP_CONSTANTS } from '../constants/AppConstants';
+import type { ParagraphDto } from '../shared/types/ApiTypes';
 
 const { Title, Paragraph } = Typography;
+
+type ParagraphUiMode = 'arrows' | 'numbers';
+
+const paragraphContainerStyle: React.CSSProperties = {
+  marginBottom: 24,
+  border: '1px solid #d9d9d9',
+  borderRadius: 8,
+  padding: 16,
+  position: 'relative',
+};
 
 const ArticlePage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const articleId = parseInt(id || '0', 10);
+  const [uiMode, setUiMode] = useState<ParagraphUiMode>('arrows');
+  const [selectedAlternatives, setSelectedAlternatives] = useState<Record<number, number>>({});
 
-  // Используем useQuery для получения данных статьи
   const { data: articleContent, isLoading, error } = useQuery({
     queryKey: [APP_CONSTANTS.QUERY_KEYS.ARTICLE_CONTENT, articleId],
     queryFn: () => getArticleContentById(articleId),
     enabled: !isNaN(articleId) && articleId > 0,
   });
+
+  const groupedParagraphs = useMemo(() => {
+    const grouped = new Map<number, ParagraphDto[]>();
+
+    articleContent?.paragraphs.forEach((paragraph) => {
+      const paragraphsAtOrder = grouped.get(paragraph.order) ?? [];
+      paragraphsAtOrder.push(paragraph);
+      grouped.set(paragraph.order, paragraphsAtOrder);
+    });
+
+    return Array.from(grouped.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([order, paragraphs]) => ({ order, paragraphs }));
+  }, [articleContent]);
+
+  const updateSelectedAlternative = (order: number, index: number, total: number) => {
+    const boundedIndex = Math.max(0, Math.min(index, total - 1));
+    setSelectedAlternatives((current) => ({ ...current, [order]: boundedIndex }));
+  };
 
   if (isLoading) {
     return (
@@ -43,9 +74,7 @@ const ArticlePage: React.FC = () => {
   if (!articleContent) {
     return (
       <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-        <Empty
-          description={APP_CONSTANTS.PLACEHOLDER_TEXT.ARTICLE_NOT_FOUND}
-        />
+        <Empty description={APP_CONSTANTS.PLACEHOLDER_TEXT.ARTICLE_NOT_FOUND} />
       </div>
     );
   }
@@ -55,13 +84,87 @@ const ArticlePage: React.FC = () => {
       <div style={{ marginBottom: APP_CONSTANTS.MARGINS.CONTENT }}>
         <Title level={2}>{articleContent.title}</Title>
       </div>
+
+      <Space direction="vertical" size="middle" style={{ marginBottom: 16 }}>
+        <Tag color="blue">UI выбора альтернатив</Tag>
+        <Segmented
+          value={uiMode}
+          onChange={(value) => setUiMode(value as ParagraphUiMode)}
+          options={[
+            { label: 'Стрелки (карусель)', value: 'arrows' },
+            { label: 'Рамка + номера', value: 'numbers' },
+          ]}
+        />
+      </Space>
+
       <div>
-        {articleContent.paragraphs.length > 0 ? (
-          articleContent.paragraphs.map((paragraph, index) => (
-            <Paragraph key={paragraph.id || index} style={{ fontSize: '16px', lineHeight: '1.8' }}>
-              {paragraph.content}
-            </Paragraph>
-          ))
+        {groupedParagraphs.length > 0 ? (
+          groupedParagraphs.map(({ order, paragraphs }) => {
+            const defaultIndex = paragraphs.findIndex((paragraph) => paragraph.isDefault);
+            const selectedIndex = selectedAlternatives[order] ?? (defaultIndex >= 0 ? defaultIndex : 0);
+            const selectedParagraph = paragraphs[selectedIndex] ?? paragraphs[0];
+            const hasAlternatives = paragraphs.length > 1;
+
+            if (uiMode === 'arrows') {
+              return (
+                <div key={order} style={{ marginBottom: 24 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    {hasAlternatives && (
+                      <Button
+                        type="text"
+                        size="small"
+                        icon={<LeftOutlined />}
+                        aria-label="Предыдущая альтернатива"
+                        onClick={() => updateSelectedAlternative(order, selectedIndex - 1, paragraphs.length)}
+                      />
+                    )}
+
+                    <div style={{ ...paragraphContainerStyle, marginBottom: 0, flex: 1 }}>
+                      <Paragraph style={{ fontSize: '16px', lineHeight: '1.8', marginBottom: 0 }}>
+                        {selectedParagraph.content}
+                      </Paragraph>
+                    </div>
+
+                    {hasAlternatives && (
+                      <Button
+                        type="text"
+                        size="small"
+                        icon={<RightOutlined />}
+                        aria-label="Следующая альтернатива"
+                        onClick={() => updateSelectedAlternative(order, selectedIndex + 1, paragraphs.length)}
+                      />
+                    )}
+                  </div>
+                </div>
+              );
+            }
+
+            return (
+              <div key={order} style={paragraphContainerStyle}>
+                <Paragraph style={{ fontSize: '16px', lineHeight: '1.8', marginBottom: hasAlternatives ? 24 : 0 }}>
+                  {selectedParagraph.content}
+                </Paragraph>
+
+                {hasAlternatives && (
+                  <div style={{ position: 'absolute', right: 12, bottom: 10 }}>
+                    <Space>
+                      {paragraphs.map((_, index) => (
+                        <Button
+                          key={`${order}-num-${index}`}
+                          shape="circle"
+                          size="small"
+                          type={index === selectedIndex ? 'primary' : 'default'}
+                          onClick={() => updateSelectedAlternative(order, index, paragraphs.length)}
+                        >
+                          {index + 1}
+                        </Button>
+                      ))}
+                    </Space>
+                  </div>
+                )}
+              </div>
+            );
+          })
         ) : (
           <Empty description={APP_CONSTANTS.PLACEHOLDER_TEXT.NO_CONTENT_AVAILABLE} />
         )}

--- a/wikiweaver.react/src/shared/types/ApiTypes.ts
+++ b/wikiweaver.react/src/shared/types/ApiTypes.ts
@@ -5,6 +5,7 @@ export interface ParagraphDto {
   id: number;
   content: string;
   order: number;
+  isDefault: boolean;
 }
 
 // Type for article content


### PR DESCRIPTION
### Motivation
- Make the first paragraph-alternatives UI mode behave as a simple carousel with only left/right arrows placed outside the paragraph frame, and expose which paragraph is the default so clients can choose sensible initial variants.

### Description
- Updated the frontend `ArticlePage` to turn the `arrows` mode into a pure carousel by removing numeric alternative buttons and placing left/right arrow controls outside the bordered paragraph container (`wikiweaver.react/src/pages/ArticlePage.tsx`).
- Kept the two UI modes selectable by the user via the segmented control labels `Стрелки (карусель)` and `Рамка + номера` (`wikiweaver.react/src/pages/ArticlePage.tsx`).
- Added `isDefault` to the client DTO (`wikiweaver.react/src/shared/types/ApiTypes.ts`) and to the server `ParagraphDto` projection so the UI can pick initial selections (`WikiWeaver.Application/DTOs/ParagraphDTOs.cs`).
- Extended `ArticleContentService` to persist `IsDefault` on create/update and revised order validation to require contiguous order groups and one default paragraph per order group (`WikiWeaver.Application/Services/ArticleContentService.cs`).

### Testing
- Ran `npm run build` in `wikiweaver.react` and the frontend production build completed successfully (✅).
- Ran `npm run lint` in `wikiweaver.react` which failed due to pre-existing unrelated lint errors in `src/hooks/useSidebar.ts` and `src/pages/AdminPage.tsx` (⚠️ failing; issues are outside these changes).
- Started the dev server with `npm run dev` and executed a Playwright script that mocked `/article/1/content` and captured screenshots for the updated arrows carousel and numbers modes (artifacts produced).