### PR TITLE
feat: add author markdown article creation flow with AI style hooks

### DIFF
--- a/WikiWeaver.Application/DTOs/ArticleContentDTOs.cs
+++ b/WikiWeaver.Application/DTOs/ArticleContentDTOs.cs
@@ -1,5 +1,11 @@
 ﻿namespace WikiWeaver.Application.DTOs
 {
+    public record ArticleContentCreateDto(
+        string Title,
+        int? NodeId,
+        List<ParagraphDto> Paragraphs
+    );
+
     public record ArticleContentDto(
         int Id,
         string Title,

--- a/WikiWeaver.Application/Services/ArticleContentService.cs
+++ b/WikiWeaver.Application/Services/ArticleContentService.cs
@@ -35,6 +35,63 @@ namespace WikiWeaver.Application.Services
             return new ArticleContentDto(article.Id, article.Title, paragraphDtos);
         }
 
+        public async Task<(ArticleContentDto? Article, string? ErrorMessage)> CreateArticleWithContentAsync(ArticleContentCreateDto dto)
+        {
+            if (string.IsNullOrWhiteSpace(dto.Title))
+            {
+                return (null, "Title is required.");
+            }
+
+            var incomingParagraphs = dto.Paragraphs ?? new List<ParagraphDto>();
+            var (valid, errorMessage) = ValidateOrder(incomingParagraphs);
+            if (!valid)
+            {
+                return (null, errorMessage);
+            }
+
+            try
+            {
+                await _uow.BeginTransactionAsync();
+
+                var article = new Article
+                {
+                    Title = dto.Title,
+                    NodeId = dto.NodeId
+                };
+
+                await _articleRepo.AddAsync(article);
+                await _uow.SaveChangesAsync();
+
+                foreach (var incoming in incomingParagraphs)
+                {
+                    var paragraph = new Paragraph
+                    {
+                        ArticleId = article.Id,
+                        Content = incoming.Content,
+                        Order = incoming.Order,
+                        IsDefault = incoming.IsDefault
+                    };
+
+                    await _paragraphRepo.AddAsync(paragraph);
+                }
+
+                await _uow.SaveChangesAsync();
+                await _uow.CommitAsync();
+
+                var paragraphDtos = (await _paragraphRepo.GetParagraphsByArticleAsync(article.Id))
+                    .OrderBy(p => p.Order)
+                    .Select(p => new ParagraphDto(p.Id, p.Content, p.Order, p.IsDefault))
+                    .ToList();
+
+                return (new ArticleContentDto(article.Id, article.Title, paragraphDtos), null);
+            }
+            catch
+            {
+                await _uow.RollbackAsync();
+                return (null, "Error occurred while creating article.");
+            }
+        }
+
         public async Task<(bool Success, string? ErrorMessage)> UpdateContentAsync(int articleId, ArticleContentDto dto)
         {
             if (!await ValidateArticleExistsAsync(articleId, dto.Id))
@@ -77,6 +134,9 @@ namespace WikiWeaver.Application.Services
 
         private (bool IsValid, string? ErrorMessage) ValidateOrder(List<ParagraphDto> paragraphs)
         {
+            if (!paragraphs.Any())
+                return (false, "At least one paragraph is required.");
+
             var orders = paragraphs.Select(p => p.Order).ToList();
             if (orders.Any(o => o < 1))
                 return (false, "Order must be >= 1.");

--- a/WikiWeaver.MinimalApi/Endpoints/ArticleContentEndpoints.cs
+++ b/WikiWeaver.MinimalApi/Endpoints/ArticleContentEndpoints.cs
@@ -1,4 +1,5 @@
-﻿using WikiWeaver.Application.Services;
+﻿using WikiWeaver.Application.DTOs;
+using WikiWeaver.Application.Services;
 
 namespace WikiWeaver.MinimalApi.Endpoints
 {
@@ -12,6 +13,18 @@ namespace WikiWeaver.MinimalApi.Endpoints
             {
                 var content = await service.GetContentByArticleIdAsync(id);
                 return content is null ? Results.NotFound() : Results.Ok(content);
+            });
+
+
+            group.MapPost("/content", async (ArticleContentCreateDto dto, ArticleContentService service) =>
+            {
+                var (article, error) = await service.CreateArticleWithContentAsync(dto);
+                if (article is null)
+                {
+                    return Results.BadRequest(new { error });
+                }
+
+                return Results.Created($"/article/{article.Id}/content", article);
             });
 
             // group.MapPut("/{id}/content", async (int id, ArticleContentDto dto, ArticleContentService service) =>

--- a/wikiweaver.react/src/app/App.tsx
+++ b/wikiweaver.react/src/app/App.tsx
@@ -6,6 +6,7 @@ import MainLayout from '../layouts/MainLayout';
 import WelcomePage from '../pages/WelcomePage';
 import ArticlePage from '../pages/ArticlePage';
 import AdminPage from '../pages/AdminPage';
+import AddArticlePage from '../pages/AddArticlePage';
 
 // Создаем экземпляр QueryClient
 const queryClient = new QueryClient();
@@ -20,6 +21,7 @@ function App() {
               <Route path="/" element={<WelcomePage />} />
               <Route path="/article/:id" element={<ArticlePage />} />
               <Route path="/admin" element={<AdminPage />} />
+              <Route path="/article/new" element={<AddArticlePage />} />
             </Routes>
           </MainLayout>
         </Router>

--- a/wikiweaver.react/src/components/SimpleMarkdownEditor.tsx
+++ b/wikiweaver.react/src/components/SimpleMarkdownEditor.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react';
+import { Button, Space, Typography } from 'antd';
+
+const { Text } = Typography;
+
+interface SimpleMarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const SimpleMarkdownEditor: React.FC<SimpleMarkdownEditorProps> = ({ value, onChange, placeholder }) => {
+  const insertAroundSelection = (prefix: string, suffix = prefix) => {
+    onChange(`${value}${prefix}текст${suffix}`);
+  };
+
+  const lineCount = useMemo(() => (value ? value.split('\n').length : 0), [value]);
+
+  return (
+    <Space direction="vertical" size="small" style={{ width: '100%' }}>
+      <Space wrap>
+        <Button size="small" onClick={() => insertAroundSelection('**')}>Bold</Button>
+        <Button size="small" onClick={() => insertAroundSelection('_')}>Italic</Button>
+        <Button size="small" onClick={() => onChange(`${value}\n## Заголовок`) }>H2</Button>
+        <Button size="small" onClick={() => onChange(`${value}\n- Пункт`) }>List</Button>
+        <Button size="small" onClick={() => onChange(`${value}\n> Цитата`) }>Quote</Button>
+      </Space>
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        style={{ width: '100%', minHeight: 160, borderRadius: 8, border: '1px solid #d9d9d9', padding: 12, fontFamily: 'monospace' }}
+      />
+      <Text type="secondary">Markdown строк: {lineCount}</Text>
+    </Space>
+  );
+};
+
+export default SimpleMarkdownEditor;

--- a/wikiweaver.react/src/layouts/MainLayout.tsx
+++ b/wikiweaver.react/src/layouts/MainLayout.tsx
@@ -22,6 +22,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
                     </Link>
                 </div>
                 <div className={styles.headerActions}>
+                    <Link to="/article/new" className={styles.adminLink}>Добавить статью</Link>
                     <Link to="/admin" className={styles.adminLink}>Admin panel</Link>
                 </div>
             </Header>

--- a/wikiweaver.react/src/pages/AddArticlePage.tsx
+++ b/wikiweaver.react/src/pages/AddArticlePage.tsx
@@ -1,0 +1,282 @@
+import React, { useMemo, useState } from 'react';
+import { Alert, Button, Card, Input, InputNumber, Modal, Radio, Space, Typography, message } from 'antd';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { createArticleContent } from '../services/Article/articleService';
+import type { ArticleContentCreateDto, ParagraphDto } from '../shared/types/ApiTypes';
+import SimpleMarkdownEditor from '../components/SimpleMarkdownEditor';
+
+const { Title, Text } = Typography;
+
+type AlternativeDraft = {
+  localId: string;
+  content: string;
+  isDefault: boolean;
+};
+
+type ParagraphGroupDraft = {
+  order: number;
+  alternatives: AlternativeDraft[];
+};
+
+const createEmptyGroup = (order: number): ParagraphGroupDraft => ({
+  order,
+  alternatives: [{ localId: crypto.randomUUID(), content: '', isDefault: true }],
+});
+
+const AddArticlePage: React.FC = () => {
+  const navigate = useNavigate();
+  const [messageApi, contextHolder] = message.useMessage();
+  const [title, setTitle] = useState('');
+  const [nodeId, setNodeId] = useState<number | null>(null);
+  const [groups, setGroups] = useState<ParagraphGroupDraft[]>([createEmptyGroup(1)]);
+  const [isImportOpen, setIsImportOpen] = useState(false);
+  const [importText, setImportText] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: (payload: ArticleContentCreateDto) => createArticleContent(payload),
+    onSuccess: (created) => {
+      messageApi.success('Статья сохранена');
+      navigate(`/article/${created.id}`);
+    },
+    onError: (error) => messageApi.error(`Ошибка сохранения: ${(error as Error).message}`),
+  });
+
+  const totalAlternatives = useMemo(
+    () => groups.reduce((sum, group) => sum + group.alternatives.length, 0),
+    [groups],
+  );
+
+  const setAlternativeContent = (groupOrder: number, localId: string, content: string) => {
+    setGroups((current) =>
+      current.map((group) =>
+        group.order !== groupOrder
+          ? group
+          : {
+              ...group,
+              alternatives: group.alternatives.map((alternative) =>
+                alternative.localId === localId ? { ...alternative, content } : alternative,
+              ),
+            },
+      ),
+    );
+  };
+
+  const setDefaultAlternative = (groupOrder: number, localId: string) => {
+    setGroups((current) =>
+      current.map((group) =>
+        group.order !== groupOrder
+          ? group
+          : {
+              ...group,
+              alternatives: group.alternatives.map((alternative) => ({
+                ...alternative,
+                isDefault: alternative.localId === localId,
+              })),
+            },
+      ),
+    );
+  };
+
+  const addParagraphGroup = () => {
+    setGroups((current) => [...current, createEmptyGroup(current.length + 1)]);
+  };
+
+  const addAlternative = (groupOrder: number) => {
+    setGroups((current) =>
+      current.map((group) =>
+        group.order !== groupOrder
+          ? group
+          : {
+              ...group,
+              alternatives: [...group.alternatives, { localId: crypto.randomUUID(), content: '', isDefault: false }],
+            },
+      ),
+    );
+  };
+
+  const removeAlternative = (groupOrder: number, localId: string) => {
+    setGroups((current) =>
+      current.map((group) => {
+        if (group.order !== groupOrder || group.alternatives.length <= 1) return group;
+
+        const alternatives = group.alternatives.filter((alternative) => alternative.localId !== localId);
+        if (!alternatives.some((alternative) => alternative.isDefault)) {
+          alternatives[0].isDefault = true;
+        }
+
+        return { ...group, alternatives };
+      }),
+    );
+  };
+
+  const improveStyleWithAi = (groupOrder?: number, localId?: string) => {
+    // TODO(WW-AI-01): call backend AI endpoint that rewrites markdown while preserving meaning and links.
+    // TODO(WW-AI-02): add per-author opt-in settings and prompt template customization.
+    messageApi.info(
+      groupOrder && localId
+        ? `ИИ-улучшение для абзаца ${groupOrder} пока не подключено.`
+        : 'ИИ-улучшение статьи пока не подключено.',
+    );
+  };
+
+  const saveArticle = () => {
+    if (!title.trim()) {
+      messageApi.warning('Укажите заголовок статьи');
+      return;
+    }
+
+    const paragraphs: ParagraphDto[] = groups.flatMap((group) =>
+      group.alternatives
+        .filter((alternative) => alternative.content.trim())
+        .map((alternative) => ({
+          id: 0,
+          content: alternative.content.trim(),
+          order: group.order,
+          isDefault: alternative.isDefault,
+        })),
+    );
+
+    if (paragraphs.length === 0) {
+      messageApi.warning('Добавьте хотя бы один заполненный абзац');
+      return;
+    }
+
+    const emptyDefaults = groups.some(
+      (group) => !group.alternatives.some((alternative) => alternative.isDefault && alternative.content.trim()),
+    );
+
+    if (emptyDefaults) {
+      messageApi.warning('Для каждого абзаца должна быть заполнена хотя бы одна версия по умолчанию');
+      return;
+    }
+
+    mutation.mutate({
+      title: title.trim(),
+      nodeId: nodeId ?? undefined,
+      paragraphs,
+    });
+  };
+
+  const importMarkdownAsParagraphs = () => {
+    const parts = importText
+      .split(/\n\s*\n/g)
+      .map((value) => value.trim())
+      .filter(Boolean);
+
+    if (parts.length === 0) {
+      messageApi.warning('Не найдено абзацев для импорта');
+      return;
+    }
+
+    setGroups(parts.map((content, index) => ({
+      order: index + 1,
+      alternatives: [{ localId: crypto.randomUUID(), content, isDefault: true }],
+    })));
+    setIsImportOpen(false);
+    setImportText('');
+    messageApi.success(`Импортировано абзацев: ${parts.length}`);
+  };
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      {contextHolder}
+      <Title level={2}>Новая статья</Title>
+      <Alert
+        type="info"
+        showIcon
+        message="Модель хранения"
+        description="Каждый абзац — это группа альтернатив. Можно сохранить только основную версию, а альтернативы добавить позже, либо сразу создать несколько версий в одном порядке."
+      />
+
+      <Card>
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Заголовок статьи" />
+          <InputNumber
+            value={nodeId ?? undefined}
+            onChange={(value) => setNodeId(value ?? null)}
+            placeholder="Node ID (необязательно)"
+            style={{ width: 240 }}
+            min={1}
+          />
+          <Space>
+            <Button onClick={() => setIsImportOpen(true)}>Импортировать черновик Markdown</Button>
+            <Button onClick={() => improveStyleWithAi()}>Улучшить стиль с помощью ИИ</Button>
+          </Space>
+          <Text type="secondary">Абзацев: {groups.length} · Версий: {totalAlternatives}</Text>
+        </Space>
+      </Card>
+
+      {groups.map((group) => (
+        <Card
+          key={group.order}
+          title={`Абзац #${group.order}`}
+          extra={<Button onClick={() => addAlternative(group.order)}>Добавить альтернативу</Button>}
+        >
+          <Space direction="vertical" size="large" style={{ width: '100%' }}>
+            <Radio.Group
+              value={group.alternatives.find((alternative) => alternative.isDefault)?.localId}
+              onChange={(event) => setDefaultAlternative(group.order, event.target.value)}
+            >
+              <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+                {group.alternatives.map((alternative, index) => (
+                  <Card
+                    key={alternative.localId}
+                    size="small"
+                    title={
+                      <Space>
+                        <Radio value={alternative.localId}>Версия {index + 1}</Radio>
+                        {alternative.isDefault && <Text type="success">По умолчанию</Text>}
+                      </Space>
+                    }
+                    extra={
+                      <Space>
+                        <Button size="small" onClick={() => improveStyleWithAi(group.order, alternative.localId)}>
+                          ИИ-стиль
+                        </Button>
+                        <Button size="small" danger onClick={() => removeAlternative(group.order, alternative.localId)}>
+                          Удалить
+                        </Button>
+                      </Space>
+                    }
+                  >
+                    <SimpleMarkdownEditor
+                      value={alternative.content}
+                      onChange={(content) => setAlternativeContent(group.order, alternative.localId, content)}
+                      placeholder="Напишите версию абзаца в Markdown"
+                    />
+                  </Card>
+                ))}
+              </Space>
+            </Radio.Group>
+          </Space>
+        </Card>
+      ))}
+
+      <Space>
+        <Button onClick={addParagraphGroup}>Добавить абзац</Button>
+        <Button type="primary" loading={mutation.isPending} onClick={saveArticle}>Сохранить статью</Button>
+      </Space>
+
+      <Modal
+        title="Импортировать черновик Markdown"
+        open={isImportOpen}
+        onCancel={() => setIsImportOpen(false)}
+        onOk={importMarkdownAsParagraphs}
+        okText="Импортировать"
+      >
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Text>Разделяйте абзацы пустой строкой. Импорт создаст по одной версии на каждый абзац.</Text>
+          <Input.TextArea
+            rows={10}
+            value={importText}
+            onChange={(event) => setImportText(event.target.value)}
+            placeholder={'Абзац 1\n\nАбзац 2\n\nАбзац 3'}
+          />
+        </Space>
+      </Modal>
+    </Space>
+  );
+};
+
+export default AddArticlePage;

--- a/wikiweaver.react/src/services/Article/articleService.ts
+++ b/wikiweaver.react/src/services/Article/articleService.ts
@@ -1,13 +1,17 @@
-import apiClient from '../../shared/api-client/ApiClient'; // Import the axios API client
-import type { ArticleContentDto } from '../../shared/types/ApiTypes'; // Import the specific DTO type
+import apiClient from '../../shared/api-client/ApiClient';
+import type { ArticleContentCreateDto, ArticleContentDto } from '../../shared/types/ApiTypes';
 
-// Fetch article content by ID
 export const getArticleContentById = async (id: number): Promise<ArticleContentDto> => {
-    const response = await apiClient.get<ArticleContentDto>(`/article/${id}/content`);
-    return response.data; // Axios automatically parses JSON and stores it in .data
+  const response = await apiClient.get<ArticleContentDto>(`/article/${id}/content`);
+  return response.data;
 };
 
-// Service object for article content (aggregation)
+export const createArticleContent = async (payload: ArticleContentCreateDto): Promise<ArticleContentDto> => {
+  const response = await apiClient.post<ArticleContentDto>('/article/content', payload);
+  return response.data;
+};
+
 export const articleService = {
-    getArticleContentById,
+  getArticleContentById,
+  createArticleContent,
 };

--- a/wikiweaver.react/src/shared/types/ApiTypes.ts
+++ b/wikiweaver.react/src/shared/types/ApiTypes.ts
@@ -15,6 +15,12 @@ export interface ArticleContentDto {
   paragraphs: ParagraphDto[];
 }
 
+export interface ArticleContentCreateDto {
+  title: string;
+  nodeId?: number;
+  paragraphs: ParagraphDto[];
+}
+
 // Type for an article linked to a navigation node
 export interface ArticleReadDto {
   id: number;


### PR DESCRIPTION
### Motivation
- Provide authors a simple markdown editor workflow so they can write full articles and save them while preserving the domain model where an article is a sequence of paragraph groups with alternatives.
- Allow authors to opt into AI-driven style improvements via a clearly marked hook so the feature can be integrated later without changing the authoring UX now.
- Support both single-version authoring and immediate multi-version authoring (alternatives per paragraph) to match existing storage and future collaboration flows.

### Description
- Added a new author page `Новая статья` at route `GET /article/new` implemented in `wikiweaver.react/src/pages/AddArticlePage.tsx` with UI to add paragraph groups, add alternatives, choose default versions, import markdown by splitting on blank lines, and save the whole article.
- Implemented a simple in-repo markdown editor `SimpleMarkdownEditor` (`wikiweaver.react/src/components/SimpleMarkdownEditor.tsx`) instead of adding an external dependency due to registry/network restrictions, and added two TODO markers (`WW-AI-01`, `WW-AI-02`) where AI integration will be wired.
- Added backend DTO `ArticleContentCreateDto` and transactional creation flow `CreateArticleWithContentAsync` in `WikiWeaver.Application/Services/ArticleContentService.cs` with validation of `order` sequence and default-per-order rules, and exposed `POST /article/content` in `WikiWeaver.MinimalApi/Endpoints/ArticleContentEndpoints.cs`.
- Updated frontend API types and service (`wikiweaver.react/src/shared/types/ApiTypes.ts`, `wikiweaver.react/src/services/Article/articleService.ts`), added header link and route for the new page (`wikiweaver.react/src/layouts/MainLayout.tsx`, `wikiweaver.react/src/app/App.tsx`).

### Testing
- Ran frontend production build with `cd wikiweaver.react && npm run build`, which completed successfully (✅).
- Ran frontend lint with `cd wikiweaver.react && npm run lint`, which failed due to pre-existing unrelated lint issues in `useSidebar.ts` and escape warnings in `AdminPage.tsx` (⚠️).
- Attempted `dotnet build WikiWeaver.sln` but the `dotnet` CLI is not available in the environment so the backend build could not be performed here (⚠️).
- Tried a Playwright page capture to verify the new page, but Chromium crashed in the container (SIGSEGV) so UI screenshot verification did not complete (⚠️).

------