### PR TITLE
fix(api): stabilize SQLite cleanup before demo reseed

### DIFF
--- a/WikiWeaver.MinimalApi/Endpoints/AdminEndpoints.cs
+++ b/WikiWeaver.MinimalApi/Endpoints/AdminEndpoints.cs
@@ -21,9 +21,13 @@ public static class AdminEndpoints
 
             if (dbContext.Database.IsSqlite())
             {
+                // Some local databases may contain older schema variations where Nodes.ArticleId
+                // is enforced as a foreign key to Articles. Nullify optional references first,
+                // then remove dependent rows in a stable order.
+                await dbContext.Database.ExecuteSqlRawAsync(
+                    "UPDATE \"Nodes\" SET \"ParentId\" = NULL, \"ArticleId\" = NULL WHERE \"ParentId\" IS NOT NULL OR \"ArticleId\" IS NOT NULL;");
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"Paragraphs\";");
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"Articles\";");
-                await dbContext.Database.ExecuteSqlRawAsync("UPDATE \"Nodes\" SET \"ParentId\" = NULL WHERE \"ParentId\" IS NOT NULL;");
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"Nodes\";");
                 await dbContext.Database.ExecuteSqlRawAsync(
                     "DELETE FROM sqlite_sequence WHERE name IN ('Paragraphs', 'Articles', 'Nodes');");


### PR DESCRIPTION
### Motivation
- Re-seeding demo data could fail with `SqliteException: FOREIGN KEY constraint failed` on local databases that have schema drift where `Nodes.ArticleId` is enforced as a foreign key, because the previous cleanup only nullified `ParentId` and then deleted dependent rows.

### Description
- Updated the SQLite branch of the `/admin/cleanup` endpoint (`WikiWeaver.MinimalApi/Endpoints/AdminEndpoints.cs`) to nullify both `ParentId` and `ArticleId` on `Nodes` before deleting `Paragraphs`, `Articles`, and `Nodes`.
- Kept the deterministic delete order (`Paragraphs` -> `Articles` -> `Nodes`) and preserved the identity reset via `DELETE FROM sqlite_sequence`, and added an inline comment explaining the reason for the extra nullification.

### Testing
- `dotnet test WikiWeaver.sln` could not be executed in this environment because `dotnet` is not available (`dotnet: command not found`).
- Verified the change by reviewing the committed code diff and confirming the transactional SQL ordering and nullification step are present and correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d466dfb0832dba12aeec5cb0699c)