### PR TITLE
fix(seed): validate and safely build demo hierarchy for reseeding

### DIFF
--- a/WikiWeaver.Infrastructure/Data/DemoDataSeeder.cs
+++ b/WikiWeaver.Infrastructure/Data/DemoDataSeeder.cs
@@ -21,38 +21,67 @@ public static class DemoDataSeeder
 
         var seedData = await LoadSeedDataAsync(cancellationToken);
 
+        ValidateSeedData(seedData);
+
+        var nodeByTitle = new Dictionary<string, Node>(StringComparer.Ordinal);
+
         var roots = seedData.Roots
             .Select(title => new Node { Title = title })
             .ToList();
 
         dbContext.Nodes.AddRange(roots);
-        await dbContext.SaveChangesAsync(cancellationToken);
 
-        var nodeByTitle = roots.ToDictionary(n => n.Title);
+        foreach (var root in roots)
+            nodeByTitle[root.Title] = root;
 
-        var childNodes = new List<Node>();
-        foreach (var seedNode in seedData.Nodes)
-        {
-            if (!nodeByTitle.TryGetValue(seedNode.ParentTitle, out var parentNode))
-                continue;
-
-            var childNode = new Node
+        var pendingNodes = seedData.Nodes
+            .Select(node => new DemoNodeSeed
             {
-                Title = seedNode.Title,
-                ParentId = parentNode.Id
-            };
+                Title = node.Title,
+                ParentTitle = node.ParentTitle
+            })
+            .ToList();
 
-            childNodes.Add(childNode);
-            nodeByTitle[childNode.Title] = childNode;
+        while (pendingNodes.Count > 0)
+        {
+            var resolvedInPass = new List<DemoNodeSeed>();
+
+            foreach (var pendingNode in pendingNodes)
+            {
+                if (!nodeByTitle.TryGetValue(pendingNode.ParentTitle, out var parentNode))
+                    continue;
+
+                var childNode = new Node
+                {
+                    Title = pendingNode.Title,
+                    Parent = parentNode
+                };
+
+                dbContext.Nodes.Add(childNode);
+                nodeByTitle[childNode.Title] = childNode;
+                resolvedInPass.Add(pendingNode);
+            }
+
+            if (resolvedInPass.Count == 0)
+            {
+                var unresolvedTitles = string.Join(", ", pendingNodes.Select(node => $"'{node.Title}' (parent: '{node.ParentTitle}')"));
+                throw new InvalidOperationException(
+                    $"Demo seed contains nodes with missing parents or cyclic dependencies: {unresolvedTitles}");
+            }
+
+            foreach (var resolvedNode in resolvedInPass)
+                pendingNodes.Remove(resolvedNode);
         }
 
-        dbContext.Nodes.AddRange(childNodes);
         await dbContext.SaveChangesAsync(cancellationToken);
 
         foreach (var seedArticle in seedData.Articles)
         {
             if (!nodeByTitle.TryGetValue(seedArticle.NodeTitle, out var node))
-                continue;
+            {
+                throw new InvalidOperationException(
+                    $"Demo seed article '{seedArticle.Title}' references unknown node title '{seedArticle.NodeTitle}'.");
+            }
 
             var article = new Article
             {
@@ -93,6 +122,46 @@ public static class DemoDataSeeder
             cancellationToken);
 
         return seedData ?? throw new InvalidOperationException("Demo seed file is empty or invalid.");
+    }
+
+    private static void ValidateSeedData(DemoSeedData seedData)
+    {
+        var duplicateRootTitles = seedData.Roots
+            .GroupBy(title => title, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        if (duplicateRootTitles.Count > 0)
+            throw new InvalidOperationException($"Demo seed contains duplicate root titles: {string.Join(", ", duplicateRootTitles)}");
+
+        var duplicateNodeTitles = seedData.Nodes
+            .GroupBy(node => node.Title, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        if (duplicateNodeTitles.Count > 0)
+            throw new InvalidOperationException($"Demo seed contains duplicate node titles: {string.Join(", ", duplicateNodeTitles)}");
+
+        var allTitles = new HashSet<string>(seedData.Roots, StringComparer.Ordinal);
+        foreach (var nodeTitle in seedData.Nodes.Select(node => node.Title))
+        {
+            if (!allTitles.Add(nodeTitle))
+                throw new InvalidOperationException($"Demo seed title is duplicated between roots/nodes: '{nodeTitle}'.");
+        }
+
+        var duplicateArticleNodeReferences = seedData.Articles
+            .GroupBy(article => article.NodeTitle, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        if (duplicateArticleNodeReferences.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Demo seed contains multiple articles for the same node title: {string.Join(", ", duplicateArticleNodeReferences)}");
+        }
     }
 
     private sealed class DemoSeedData

--- a/WikiWeaver.MinimalApi/Endpoints/AdminEndpoints.cs
+++ b/WikiWeaver.MinimalApi/Endpoints/AdminEndpoints.cs
@@ -21,9 +21,13 @@ public static class AdminEndpoints
 
             if (dbContext.Database.IsSqlite())
             {
+                // Some local databases may contain older schema variations where Nodes.ArticleId
+                // is enforced as a foreign key to Articles. Nullify optional references first,
+                // then remove dependent rows in a stable order.
+                await dbContext.Database.ExecuteSqlRawAsync(
+                    "UPDATE \"Nodes\" SET \"ParentId\" = NULL, \"ArticleId\" = NULL WHERE \"ParentId\" IS NOT NULL OR \"ArticleId\" IS NOT NULL;");
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"Paragraphs\";");
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"Articles\";");
-                await dbContext.Database.ExecuteSqlRawAsync("UPDATE \"Nodes\" SET \"ParentId\" = NULL WHERE \"ParentId\" IS NOT NULL;");
                 await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM \"Nodes\";");
                 await dbContext.Database.ExecuteSqlRawAsync(
                     "DELETE FROM sqlite_sequence WHERE name IN ('Paragraphs', 'Articles', 'Nodes');");


### PR DESCRIPTION
### Motivation
- Reseeding demo data could still fail due to malformed or deeply nested JSON where node parent references, duplicate titles, or article->node references produce FK or ordering errors during insertion. 
- Make seeding deterministic and fail early with clear errors so local demos don't break startup or admin reseed flows that assume a consistent seed file.

### Description
- Added validation in `WikiWeaver.Infrastructure/Data/DemoDataSeeder.cs` to detect duplicate root/node titles, title collisions between roots and nodes, and multiple articles targeting the same `nodeTitle`, and throw descriptive `InvalidOperationException`s on failure. 
- Reworked node creation to build nodes in dependency-safe passes: roots are inserted first, then pending nodes are resolved iteratively by available parents and linked via the navigation property (`Parent`) rather than trying to set `ParentId` directly. 
- Added an explicit error when an article references a missing node title to avoid silently skipping content and to provide actionable diagnostics. 
- These changes make demo seeding robust against malformed `philosophy-demo-seed.json` and complement prior SQLite cleanup stabilization.

### Testing
- Ran a JSON consistency check via a `python` script that verifies missing parents, duplicate titles, duplicate article references and unknown article nodes (the script returned no issues and passed). 
- Ran an ordering-check `python` script that confirms no node references a parent appearing later in the file (passed). 
- Attempted `dotnet test WikiWeaver.sln` but it could not run in this environment because `dotnet` is not available (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d466dfb0832dba12aeec5cb0699c)