### PR TITLE
fix(seed): align demo seeder with paragraph object schema

### DIFF
--- a/WikiWeaver.Infrastructure/Data/DemoDataSeeder.cs
+++ b/WikiWeaver.Infrastructure/Data/DemoDataSeeder.cs
@@ -95,40 +95,13 @@ public static class DemoDataSeeder
 
         await dbContext.SaveChangesAsync(cancellationToken);
     }
-    private static IEnumerable<Paragraph> BuildParagraphs(List<string> rawParagraphs)
+    private static IEnumerable<Paragraph> BuildParagraphs(List<DemoParagraphSeed> paragraphSeeds)
     {
-        var currentOrder = 0;
-
-        foreach (var rawParagraph in rawParagraphs)
+        for (var index = 0; index < paragraphSeeds.Count; index++)
         {
-            var isAlternative = rawParagraph.StartsWith("[ALT]", StringComparison.Ordinal);
-            var content = isAlternative
-                ? rawParagraph["[ALT]".Length..].TrimStart()
-                : rawParagraph;
-
-            if (isAlternative)
-            {
-                if (currentOrder == 0)
-                    throw new InvalidOperationException("Alternative paragraph cannot be the first paragraph in an article.");
-
-                yield return new Paragraph
-                {
-                    Content = content,
-                    Order = currentOrder,
-                    IsDefault = false
-                };
-
-                continue;
-            }
-
-            currentOrder++;
-
-            yield return new Paragraph
-            {
-                Content = content,
-                Order = currentOrder,
-                IsDefault = true
-            };
+            var order = index + 1;
+            foreach (var paragraph in BuildParagraphs(paragraphSeeds[index], order))
+                yield return paragraph;
         }
     }
 
@@ -217,34 +190,22 @@ public static class DemoDataSeeder
             if (article.Paragraphs.Count == 0)
                 throw new InvalidOperationException($"Demo seed article '{article.Title}' must contain at least one paragraph.");
 
-            var defaultParagraphCount = 0;
             foreach (var paragraph in article.Paragraphs)
             {
-                var isAlternative = paragraph.StartsWith("[ALT]", StringComparison.Ordinal);
-                var normalizedContent = isAlternative
-                    ? paragraph["[ALT]".Length..].TrimStart()
-                    : paragraph;
-
-                if (string.IsNullOrWhiteSpace(normalizedContent))
+                if (string.IsNullOrWhiteSpace(paragraph.Default))
                 {
                     throw new InvalidOperationException(
-                        $"Demo seed article '{article.Title}' contains an empty paragraph.");
+                        $"Demo seed article '{article.Title}' contains an empty default paragraph.");
                 }
 
-                if (isAlternative && defaultParagraphCount == 0)
+                foreach (var alternative in paragraph.Alternatives)
                 {
-                    throw new InvalidOperationException(
-                        $"Demo seed article '{article.Title}' starts with an alternative paragraph before any default paragraph.");
+                    if (string.IsNullOrWhiteSpace(alternative))
+                    {
+                        throw new InvalidOperationException(
+                            $"Demo seed article '{article.Title}' contains an empty alternative paragraph.");
+                    }
                 }
-
-                if (!isAlternative)
-                    defaultParagraphCount++;
-            }
-
-            if (defaultParagraphCount == 0)
-            {
-                throw new InvalidOperationException(
-                    $"Demo seed article '{article.Title}' must contain at least one default paragraph.");
             }
         }
     }


### PR DESCRIPTION
### Motivation
- The demo seed data format was changed from plain paragraph strings using an "[ALT]" marker to paragraph objects (`DemoParagraphSeed`), but the seeder still parsed strings which caused seeding to fail.
- The goal is to make the seeder consume the new paragraph object schema, preserve deterministic ordering, and validate both default and alternative paragraph content.

### Description
- Replaced legacy `BuildParagraphs(List<string>)` with `BuildParagraphs(List<DemoParagraphSeed>)` that maps each `DemoParagraphSeed` to `Paragraph` entities and assigns `Order = index + 1`.
- Kept `BuildParagraphs(DemoParagraphSeed, int)` to produce one default `Paragraph` and zero-or-more alternative `Paragraph`s with correct `IsDefault` flags.
- Updated `ValidateSeedData` to assert non-empty `Default` and non-empty `Alternatives` entries and removed validations tied to the old `[ALT]` string marker.
- Change is localized to `WikiWeaver.Infrastructure/Data/DemoDataSeeder.cs` with no other behavioral changes across the codebase.

### Testing
- `dotnet test WikiWeaver.sln` — couldn't run in this environment because the `dotnet` CLI is not available, so no automated tests were executed here; please run the test suite in CI or a local environment with `.NET` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699905b9c1cc832db82af140ceb6c690)