### PR TITLE
Fix EF Core migration discovery for Admin and AI provider tables

### DIFF
--- a/WikiWeaver.Infrastructure/Migrations/20260220090000_AddAiProviderSettings.cs
+++ b/WikiWeaver.Infrastructure/Migrations/20260220090000_AddAiProviderSettings.cs
@@ -1,9 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 #nullable disable
 
 namespace WikiWeaver.Infrastructure.Migrations
 {
+    [DbContext(typeof(Data.WikiWeaverDbContext))]
+    [Migration("20260220090000_AddAiProviderSettings")]
     public partial class AddAiProviderSettings : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/WikiWeaver.Infrastructure/Migrations/20260221000100_AddAdminAuth.cs
+++ b/WikiWeaver.Infrastructure/Migrations/20260221000100_AddAdminAuth.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 #nullable disable
 
 namespace WikiWeaver.Infrastructure.Migrations
 {
+    [DbContext(typeof(Data.WikiWeaverDbContext))]
+    [Migration("20260221000100_AddAdminAuth")]
     public partial class AddAdminAuth : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
### Motivation
- `Database.MigrateAsync()` did not pick up some migrations, so the `AdminUsers` (and related) table was missing at runtime causing "no such table: AdminUsers" errors when querying the DB.

### Description
- Added `using Microsoft.EntityFrameworkCore.Infrastructure;` to the two affected migration files.
- Added `[DbContext(typeof(Data.WikiWeaverDbContext))]` and `[Migration("<migration-name>")]` attributes to `20260220090000_AddAiProviderSettings.cs` and `20260221000100_AddAdminAuth.cs` so EF Core can discover and apply them at runtime.
- Changes are limited to migration metadata and do not alter migration SQL in the `Up`/`Down` methods.

### Testing
- Attempted to run `dotnet build WikiWeaver.sln`, but the environment does not have the `dotnet` CLI installed so a build could not be executed (`command not found`).
- Performed repository inspection to confirm the attributes were added to both migration files and validated the files contain the expected `[DbContext]` and `[Migration]` annotations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aafc66b5c832daf871db28dfc524c)