### PR TITLE
fix(sidebar): enable navigation search filtering

### DIFF
--- a/wikiweaver.react/src/components/Sidebar.tsx
+++ b/wikiweaver.react/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { Layout, Spin, Alert, Input } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import { LoadingOutlined } from '@ant-design/icons';
@@ -8,18 +8,55 @@ import NavigationTree from './NavigationTree';
 import { APP_CONSTANTS } from '../constants/AppConstants';
 import { locale } from '../localization';
 import styles from './Sidebar.module.css';
+import type { NavigationNodeDto } from '../shared/types/ApiTypes';
 
 const { Sider } = Layout;
+
+const filterNavigationTree = (nodes: NavigationNodeDto[], searchValue: string): NavigationNodeDto[] => {
+  const normalizedSearch = searchValue.trim().toLowerCase();
+
+  if (!normalizedSearch) {
+    return nodes;
+  }
+
+  return nodes.reduce<NavigationNodeDto[]>((filteredNodes, node) => {
+    const filteredChildren = node.children
+      ? filterNavigationTree(node.children, normalizedSearch)
+      : [];
+
+    const isNodeMatch = node.title.toLowerCase().includes(normalizedSearch);
+    const isArticleMatch = node.article?.title.toLowerCase().includes(normalizedSearch) ?? false;
+
+    if (isNodeMatch || isArticleMatch || filteredChildren.length > 0) {
+      filteredNodes.push({
+        ...node,
+        children: filteredChildren,
+      });
+    }
+
+    return filteredNodes;
+  }, []);
+};
 
 interface SidebarProps {
   collapsed: boolean;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
+  const [searchValue, setSearchValue] = useState('');
+
   const { data: navigationTree, isLoading, error } = useQuery({
     queryKey: [APP_CONSTANTS.QUERY_KEYS.NAVIGATION_TREE],
     queryFn: getNavigationTree,
   });
+
+  const filteredNavigationTree = useMemo(() => {
+    if (!navigationTree) {
+      return undefined;
+    }
+
+    return filterNavigationTree(navigationTree, searchValue);
+  }, [navigationTree, searchValue]);
 
   return (
     <Sider
@@ -36,7 +73,9 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
             className={styles.searchInput}
             prefix={<SearchOutlined />}
             placeholder={locale.layout.navigation.searchPlaceholder}
-            readOnly
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+            allowClear
           />
         </div>
       )}
@@ -56,7 +95,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
               className={styles.errorAlert}
             />
           ) : (
-            <NavigationTree navigationTree={navigationTree} />
+            <NavigationTree navigationTree={filteredNavigationTree} />
           )}
         </div>
       )}


### PR DESCRIPTION
### Motivation
- The sidebar search input was rendered `readOnly`, preventing users from filtering the navigation tree and degrading discovery UX.
- The intent is to enable client-side filtering that matches both node and article titles while preserving parent nodes for matched descendants.

### Description
- Added local `searchValue` state in `Sidebar` and connected it to the search `Input` via `value` and `onChange`, and enabled `allowClear` instead of `readOnly`.
- Implemented recursive `filterNavigationTree(nodes, searchValue)` which matches `node.title` and `article.title` and keeps parents of matching children.
- Memoized filtered results with `useMemo` and passed the filtered tree into `NavigationTree` instead of the raw data.
- Imported `NavigationNodeDto` type for type-safety and kept existing loading/error handling intact.

### Testing
- `npm run lint` - passed.
- `npm run build` - passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699abad1376c832da0d5f7c85099cbed)