### PR TITLE
fix(article): enable cyclic wrap-around for arrow carousel

### DIFF
--- a/wikiweaver.react/src/pages/ArticlePage.tsx
+++ b/wikiweaver.react/src/pages/ArticlePage.tsx
@@ -49,9 +49,19 @@ const ArticlePage: React.FC = () => {
       .map(([order, paragraphs]) => ({ order, paragraphs }));
   }, [articleContent]);
 
-  const updateSelectedAlternative = (order: number, index: number, total: number) => {
+  const normalizeAlternativeIndex = (index: number, total: number) => {
+    if (total <= 0) return 0;
+    return ((index % total) + total) % total;
+  };
+
+  const selectAlternative = (order: number, index: number, total: number) => {
     const boundedIndex = Math.max(0, Math.min(index, total - 1));
     setSelectedAlternatives((current) => ({ ...current, [order]: boundedIndex }));
+  };
+
+  const moveAlternative = (order: number, currentIndex: number, direction: -1 | 1, total: number) => {
+    const nextIndex = normalizeAlternativeIndex(currentIndex + direction, total);
+    setSelectedAlternatives((current) => ({ ...current, [order]: nextIndex }));
   };
 
   if (isLoading) {
@@ -114,7 +124,7 @@ const ArticlePage: React.FC = () => {
                       size="small"
                       icon={<LeftOutlined />}
                       aria-label={locale.articlePage.previousAlternative}
-                      onClick={() => updateSelectedAlternative(order, selectedIndex - 1, paragraphs.length)}
+                      onClick={() => moveAlternative(order, selectedIndex, -1, paragraphs.length)}
                     />
 
                     <div className={styles.paragraphContainer} style={{ marginBottom: 0, flex: 1 }}>
@@ -128,7 +138,7 @@ const ArticlePage: React.FC = () => {
                       size="small"
                       icon={<RightOutlined />}
                       aria-label={locale.articlePage.nextAlternative}
-                      onClick={() => updateSelectedAlternative(order, selectedIndex + 1, paragraphs.length)}
+                      onClick={() => moveAlternative(order, selectedIndex, 1, paragraphs.length)}
                     />
                   </div>
                 </div>
@@ -149,7 +159,7 @@ const ArticlePage: React.FC = () => {
                         shape="circle"
                         size="small"
                         type={index === selectedIndex ? 'primary' : 'default'}
-                        onClick={() => updateSelectedAlternative(order, index, paragraphs.length)}
+                        onClick={() => selectAlternative(order, index, paragraphs.length)}
                       >
                         {index + 1}
                       </Button>


### PR DESCRIPTION
### Motivation
- Make arrow-based paragraph alternative navigation behave like a true carousel by wrapping from first to last and vice versa, and avoid hardcoded boundary checks by using a reusable index normalization.

### Description
- Added `normalizeAlternativeIndex(index, total)` to compute wrapped indexes using modulo arithmetic.
- Introduced `moveAlternative` for cyclic arrow navigation and `selectAlternative` for bounded direct selection to keep behaviors explicit and separate.
- Updated arrow button handlers to use `moveAlternative` while numeric buttons use `selectAlternative`, without changing render structure.

### Testing
- `npm run lint` — passed.
- `npm run build` (TypeScript + Vite) — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699abc2946ac832da4ed37e0c5d7b082)