### PR TITLE
refactor(frontend): split AddArticlePage into reusable editor blocks

### DIFF
--- a/wikiweaver.react/src/pages/AddArticlePage.tsx
+++ b/wikiweaver.react/src/pages/AddArticlePage.tsx
@@ -1,30 +1,26 @@
 import React, { useMemo, useState } from 'react';
-import { Alert, Button, Card, Input, InputNumber, Modal, Radio, Space, Typography, message } from 'antd';
+import { Alert, Button, Card, Input, InputNumber, Modal, Space, Typography, message } from 'antd';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { createArticleContent } from '../services/Article/articleService';
 import { styleMarkdownWithAi } from '../services/adminService';
-import type { ArticleContentCreateDto, ParagraphDto } from '../shared/types/ApiTypes';
-import SimpleMarkdownEditor from '../components/SimpleMarkdownEditor';
+import type { ArticleContentCreateDto } from '../shared/types/ApiTypes';
 import { locale } from '../localization';
+import ParagraphGroupEditor from './add-article/ParagraphGroupEditor';
+import {
+  addAlternativeToGroups,
+  buildParagraphDtos,
+  collectAiImprovementQueue,
+  createEmptyGroup,
+  hasGroupWithoutFilledDefault,
+  importGroupsFromMarkdown,
+  removeAlternativeFromGroups,
+  setAlternativeContentInGroups,
+  setDefaultAlternativeInGroups,
+} from './add-article/draftHelpers';
+import type { ParagraphGroupDraft } from './add-article/types';
 
 const { Title, Text } = Typography;
-
-type AlternativeDraft = {
-  localId: string;
-  content: string;
-  isDefault: boolean;
-};
-
-type ParagraphGroupDraft = {
-  order: number;
-  alternatives: AlternativeDraft[];
-};
-
-const createEmptyGroup = (order: number): ParagraphGroupDraft => ({
-  order,
-  alternatives: [{ localId: crypto.randomUUID(), content: '', isDefault: true }],
-});
 
 const AddArticlePage: React.FC = () => {
   const navigate = useNavigate();
@@ -56,34 +52,11 @@ const AddArticlePage: React.FC = () => {
   );
 
   const setAlternativeContent = (groupOrder: number, localId: string, content: string) => {
-    setGroups((current) =>
-      current.map((group) =>
-        group.order !== groupOrder
-          ? group
-          : {
-              ...group,
-              alternatives: group.alternatives.map((alternative) =>
-                alternative.localId === localId ? { ...alternative, content } : alternative,
-              ),
-            },
-      ),
-    );
+    setGroups((current) => setAlternativeContentInGroups(current, groupOrder, localId, content));
   };
 
   const setDefaultAlternative = (groupOrder: number, localId: string) => {
-    setGroups((current) =>
-      current.map((group) =>
-        group.order !== groupOrder
-          ? group
-          : {
-              ...group,
-              alternatives: group.alternatives.map((alternative) => ({
-                ...alternative,
-                isDefault: alternative.localId === localId,
-              })),
-            },
-      ),
-    );
+    setGroups((current) => setDefaultAlternativeInGroups(current, groupOrder, localId));
   };
 
   const addParagraphGroup = () => {
@@ -91,31 +64,11 @@ const AddArticlePage: React.FC = () => {
   };
 
   const addAlternative = (groupOrder: number) => {
-    setGroups((current) =>
-      current.map((group) =>
-        group.order !== groupOrder
-          ? group
-          : {
-              ...group,
-              alternatives: [...group.alternatives, { localId: crypto.randomUUID(), content: '', isDefault: false }],
-            },
-      ),
-    );
+    setGroups((current) => addAlternativeToGroups(current, groupOrder));
   };
 
   const removeAlternative = (groupOrder: number, localId: string) => {
-    setGroups((current) =>
-      current.map((group) => {
-        if (group.order !== groupOrder || group.alternatives.length <= 1) return group;
-
-        const alternatives = group.alternatives.filter((alternative) => alternative.localId !== localId);
-        if (!alternatives.some((alternative) => alternative.isDefault)) {
-          alternatives[0].isDefault = true;
-        }
-
-        return { ...group, alternatives };
-      }),
-    );
+    setGroups((current) => removeAlternativeFromGroups(current, groupOrder, localId));
   };
 
   const improveSingleAlternativeWithAi = async (groupOrder: number, localId: string) => {
@@ -137,12 +90,7 @@ const AddArticlePage: React.FC = () => {
   };
 
   const improveAllWithAi = async () => {
-    const queue = groups
-      .flatMap((group) =>
-        group.alternatives
-          .filter((alternative) => alternative.content.trim())
-          .map((alternative) => ({ groupOrder: group.order, localId: alternative.localId, content: alternative.content })),
-      );
+    const queue = collectAiImprovementQueue(groups);
 
     if (queue.length === 0) {
       messageApi.warning(t.warnings.noParagraphsForAi);
@@ -166,25 +114,14 @@ const AddArticlePage: React.FC = () => {
       return;
     }
 
-    const paragraphs: ParagraphDto[] = groups.flatMap((group) =>
-      group.alternatives
-        .filter((alternative) => alternative.content.trim())
-        .map((alternative) => ({
-          id: 0,
-          content: alternative.content.trim(),
-          order: group.order,
-          isDefault: alternative.isDefault,
-        })),
-    );
+    const paragraphs = buildParagraphDtos(groups);
 
     if (paragraphs.length === 0) {
       messageApi.warning(t.warnings.paragraphRequired);
       return;
     }
 
-    const emptyDefaults = groups.some(
-      (group) => !group.alternatives.some((alternative) => alternative.isDefault && alternative.content.trim()),
-    );
+    const emptyDefaults = hasGroupWithoutFilledDefault(groups);
 
     if (emptyDefaults) {
       messageApi.warning(t.warnings.defaultRequired);
@@ -199,23 +136,17 @@ const AddArticlePage: React.FC = () => {
   };
 
   const importMarkdownAsParagraphs = () => {
-    const parts = importText
-      .split(/\n\s*\n/g)
-      .map((value) => value.trim())
-      .filter(Boolean);
+    const importedGroups = importGroupsFromMarkdown(importText);
 
-    if (parts.length === 0) {
+    if (importedGroups.length === 0) {
       messageApi.warning(t.warnings.importEmpty);
       return;
     }
 
-    setGroups(parts.map((content, index) => ({
-      order: index + 1,
-      alternatives: [{ localId: crypto.randomUUID(), content, isDefault: true }],
-    })));
+    setGroups(importedGroups);
     setIsImportOpen(false);
     setImportText('');
-    messageApi.success(`${t.importedParagraphs}: ${parts.length}`);
+    messageApi.success(`${t.importedParagraphs}: ${importedGroups.length}`);
   };
 
   return (
@@ -243,49 +174,16 @@ const AddArticlePage: React.FC = () => {
       </Card>
 
       {groups.map((group) => (
-        <Card
+        <ParagraphGroupEditor
           key={group.order}
-          title={`${t.paragraphTitle} #${group.order}`}
-          extra={<Button onClick={() => addAlternative(group.order)}>{t.addAlternative}</Button>}
-        >
-          <Space direction="vertical" size="large" style={{ width: '100%' }}>
-            <Radio.Group
-              value={group.alternatives.find((alternative) => alternative.isDefault)?.localId}
-              onChange={(event) => setDefaultAlternative(group.order, event.target.value)}
-            >
-              <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-                {group.alternatives.map((alternative, index) => (
-                  <Card
-                    key={alternative.localId}
-                    size="small"
-                    title={
-                      <Space>
-                        <Radio value={alternative.localId}>{t.version} {index + 1}</Radio>
-                        {alternative.isDefault && <Text type="success">{t.defaultLabel}</Text>}
-                      </Space>
-                    }
-                    extra={
-                      <Space>
-                        <Button size="small" loading={styleMutation.isPending} onClick={() => improveSingleAlternativeWithAi(group.order, alternative.localId)}>
-                          {t.aiStyle}
-                        </Button>
-                        <Button size="small" danger onClick={() => removeAlternative(group.order, alternative.localId)}>
-                          {t.remove}
-                        </Button>
-                      </Space>
-                    }
-                  >
-                    <SimpleMarkdownEditor
-                      value={alternative.content}
-                      onChange={(content) => setAlternativeContent(group.order, alternative.localId, content)}
-                      placeholder={t.editorPlaceholder}
-                    />
-                  </Card>
-                ))}
-              </Space>
-            </Radio.Group>
-          </Space>
-        </Card>
+          group={group}
+          isAiBusy={styleMutation.isPending}
+          onAddAlternative={addAlternative}
+          onSetDefault={setDefaultAlternative}
+          onImproveWithAi={improveSingleAlternativeWithAi}
+          onRemoveAlternative={removeAlternative}
+          onContentChange={setAlternativeContent}
+        />
       ))}
 
       <Space>

--- a/wikiweaver.react/src/pages/add-article/ParagraphGroupEditor.tsx
+++ b/wikiweaver.react/src/pages/add-article/ParagraphGroupEditor.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Button, Card, Radio, Space, Typography } from 'antd';
+import SimpleMarkdownEditor from '../../components/SimpleMarkdownEditor';
+import { locale } from '../../localization';
+import type { ParagraphGroupDraft } from './types';
+
+const { Text } = Typography;
+
+type ParagraphGroupEditorProps = {
+  group: ParagraphGroupDraft;
+  isAiBusy: boolean;
+  onAddAlternative: (groupOrder: number) => void;
+  onSetDefault: (groupOrder: number, localId: string) => void;
+  onImproveWithAi: (groupOrder: number, localId: string) => void;
+  onRemoveAlternative: (groupOrder: number, localId: string) => void;
+  onContentChange: (groupOrder: number, localId: string, content: string) => void;
+};
+
+const ParagraphGroupEditor: React.FC<ParagraphGroupEditorProps> = ({
+  group,
+  isAiBusy,
+  onAddAlternative,
+  onSetDefault,
+  onImproveWithAi,
+  onRemoveAlternative,
+  onContentChange,
+}) => {
+  const t = locale.addArticlePage;
+
+  return (
+    <Card
+      title={`${t.paragraphTitle} #${group.order}`}
+      extra={<Button onClick={() => onAddAlternative(group.order)}>{t.addAlternative}</Button>}
+    >
+      <Radio.Group
+        value={group.alternatives.find((alternative) => alternative.isDefault)?.localId}
+        onChange={(event) => onSetDefault(group.order, event.target.value)}
+      >
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          {group.alternatives.map((alternative, index) => (
+            <Card
+              key={alternative.localId}
+              size="small"
+              title={(
+                <Space>
+                  <Radio value={alternative.localId}>{t.version} {index + 1}</Radio>
+                  {alternative.isDefault && <Text type="success">{t.defaultLabel}</Text>}
+                </Space>
+              )}
+              extra={(
+                <Space>
+                  <Button
+                    size="small"
+                    loading={isAiBusy}
+                    onClick={() => onImproveWithAi(group.order, alternative.localId)}
+                  >
+                    {t.aiStyle}
+                  </Button>
+                  <Button
+                    size="small"
+                    danger
+                    onClick={() => onRemoveAlternative(group.order, alternative.localId)}
+                  >
+                    {t.remove}
+                  </Button>
+                </Space>
+              )}
+            >
+              <SimpleMarkdownEditor
+                value={alternative.content}
+                onChange={(content) => onContentChange(group.order, alternative.localId, content)}
+                placeholder={t.editorPlaceholder}
+              />
+            </Card>
+          ))}
+        </Space>
+      </Radio.Group>
+    </Card>
+  );
+};
+
+export default ParagraphGroupEditor;

--- a/wikiweaver.react/src/pages/add-article/draftHelpers.ts
+++ b/wikiweaver.react/src/pages/add-article/draftHelpers.ts
@@ -1,0 +1,121 @@
+import type { ParagraphDto } from '../../shared/types/ApiTypes';
+import type { ParagraphGroupDraft } from './types';
+
+export const createEmptyGroup = (order: number): ParagraphGroupDraft => ({
+  order,
+  alternatives: [{ localId: crypto.randomUUID(), content: '', isDefault: true }],
+});
+
+export const setAlternativeContentInGroups = (
+  groups: ParagraphGroupDraft[],
+  groupOrder: number,
+  localId: string,
+  content: string,
+): ParagraphGroupDraft[] =>
+  groups.map((group) =>
+    group.order !== groupOrder
+      ? group
+      : {
+          ...group,
+          alternatives: group.alternatives.map((alternative) =>
+            alternative.localId === localId ? { ...alternative, content } : alternative,
+          ),
+        },
+  );
+
+export const setDefaultAlternativeInGroups = (
+  groups: ParagraphGroupDraft[],
+  groupOrder: number,
+  localId: string,
+): ParagraphGroupDraft[] =>
+  groups.map((group) =>
+    group.order !== groupOrder
+      ? group
+      : {
+          ...group,
+          alternatives: group.alternatives.map((alternative) => ({
+            ...alternative,
+            isDefault: alternative.localId === localId,
+          })),
+        },
+  );
+
+export const addAlternativeToGroups = (
+  groups: ParagraphGroupDraft[],
+  groupOrder: number,
+): ParagraphGroupDraft[] =>
+  groups.map((group) =>
+    group.order !== groupOrder
+      ? group
+      : {
+          ...group,
+          alternatives: [
+            ...group.alternatives,
+            { localId: crypto.randomUUID(), content: '', isDefault: false },
+          ],
+        },
+  );
+
+export const removeAlternativeFromGroups = (
+  groups: ParagraphGroupDraft[],
+  groupOrder: number,
+  localId: string,
+): ParagraphGroupDraft[] =>
+  groups.map((group) => {
+    if (group.order !== groupOrder || group.alternatives.length <= 1) {
+      return group;
+    }
+
+    const alternatives = group.alternatives.filter(
+      (alternative) => alternative.localId !== localId,
+    );
+
+    if (!alternatives.some((alternative) => alternative.isDefault)) {
+      alternatives[0].isDefault = true;
+    }
+
+    return { ...group, alternatives };
+  });
+
+export const collectAiImprovementQueue = (groups: ParagraphGroupDraft[]) =>
+  groups.flatMap((group) =>
+    group.alternatives
+      .filter((alternative) => alternative.content.trim())
+      .map((alternative) => ({
+        groupOrder: group.order,
+        localId: alternative.localId,
+        content: alternative.content,
+      })),
+  );
+
+export const buildParagraphDtos = (groups: ParagraphGroupDraft[]): ParagraphDto[] =>
+  groups.flatMap((group) =>
+    group.alternatives
+      .filter((alternative) => alternative.content.trim())
+      .map((alternative) => ({
+        id: 0,
+        content: alternative.content.trim(),
+        order: group.order,
+        isDefault: alternative.isDefault,
+      })),
+  );
+
+export const hasGroupWithoutFilledDefault = (groups: ParagraphGroupDraft[]): boolean =>
+  groups.some(
+    (group) =>
+      !group.alternatives.some(
+        (alternative) => alternative.isDefault && alternative.content.trim(),
+      ),
+  );
+
+export const importGroupsFromMarkdown = (importText: string): ParagraphGroupDraft[] => {
+  const parts = importText
+    .split(/\n\s*\n/g)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return parts.map((content, index) => ({
+    order: index + 1,
+    alternatives: [{ localId: crypto.randomUUID(), content, isDefault: true }],
+  }));
+};

--- a/wikiweaver.react/src/pages/add-article/types.ts
+++ b/wikiweaver.react/src/pages/add-article/types.ts
@@ -1,0 +1,10 @@
+export type AlternativeDraft = {
+  localId: string;
+  content: string;
+  isDefault: boolean;
+};
+
+export type ParagraphGroupDraft = {
+  order: number;
+  alternatives: AlternativeDraft[];
+};


### PR DESCRIPTION
### Motivation
- Simplify `AddArticlePage` by extracting reusable UI and logic so the page component is smaller and easier to read.
- Isolate paragraph-draft transformations and updates to make state changes easier to reason about and reuse.

### Description
- Extracted paragraph group UI into a new `ParagraphGroupEditor` component at `src/pages/add-article/ParagraphGroupEditor.tsx` and updated `AddArticlePage` to use it.
- Moved paragraph-draft helpers (create/update/remove alternatives, import, DTO building, AI queue) into `src/pages/add-article/draftHelpers.ts` and replaced inline logic in `AddArticlePage` with those helpers.
- Centralized types `AlternativeDraft` and `ParagraphGroupDraft` in `src/pages/add-article/types.ts` and adjusted imports accordingly.
- Preserved existing behavior and public API of the page while reducing complexity and duplication in the component.

### Testing
- Ran linter with `npm run lint` and it completed successfully.
- Built the frontend with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac0a29ad8832dadc972bffae8b894)