### PR TITLE
feat(admin): move article creation into admin tab; widen paragraph editor input

### DIFF
--- a/wikiweaver.react/src/layouts/MainLayout.module.css
+++ b/wikiweaver.react/src/layouts/MainLayout.module.css
@@ -9,7 +9,7 @@
   background: #ffffff;
   border-bottom: 1px solid #f0f0f0;
   display: grid;
-  grid-template-columns: auto auto 1fr auto;
+  grid-template-columns: auto auto 1fr;
   align-items: center;
   gap: 8px;
 }
@@ -51,16 +51,6 @@
   font-size: 16px;
 }
 
-.headerCenter {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.topMenu {
-  border-bottom: none;
-  min-width: 280px;
-  background: transparent;
-}
 
 .pageLayout {
   min-height: calc(100vh - 64px);

--- a/wikiweaver.react/src/layouts/MainLayout.tsx
+++ b/wikiweaver.react/src/layouts/MainLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Layout, Menu, Button, Typography, Tooltip } from 'antd';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Layout, Button, Typography, Tooltip } from 'antd';
+import { Link, useNavigate } from 'react-router-dom';
 import { LeftOutlined, RightOutlined, SafetyCertificateOutlined, LogoutOutlined } from '@ant-design/icons';
 import Sidebar from '../components/Sidebar';
 import { useSidebar } from '../hooks/useSidebar';
@@ -17,12 +17,7 @@ interface MainLayoutProps {
     children: React.ReactNode;
 }
 
-const topMenuItems = [
-    { key: '/article/new', label: <Link to="/article/new">{locale.layout.menu.addArticle}</Link> }
-];
-
 const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
-    const location = useLocation();
     const navigate = useNavigate();
     const { collapsed, toggleCollapsed } = useSidebar();
     const isAdmin = isAdminAuthenticated();
@@ -49,15 +44,6 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
                         icon={collapsed ? <RightOutlined /> : <LeftOutlined />}
                         onClick={toggleCollapsed}
                         className={styles.navToggleButton}
-                    />
-                </div>
-
-                <div className={styles.headerCenter}>
-                    <Menu
-                        mode="horizontal"
-                        className={styles.topMenu}
-                        items={topMenuItems}
-                        selectedKeys={[location.pathname]}
                     />
                 </div>
 

--- a/wikiweaver.react/src/localization/ru.ts
+++ b/wikiweaver.react/src/localization/ru.ts
@@ -148,6 +148,10 @@ export const ru = {
     generateInviteToken: 'Сгенерировать invite token',
     inviteTokenGenerated: 'Invite token сгенерирован',
     inviteTokenGenerateFailed: 'Не удалось сгенерировать invite token',
+    createArticleTab: 'Создание статьи',
+    createArticleTitle: 'Создание новой статьи',
+    createArticleDescription: 'Переход к форме создания статьи вынесен в отдельную вкладку админ-панели.',
+    createArticleAction: 'Перейти к созданию статьи',
   },
   adminLoginPage: {
     loginSuccess: 'Сессия администратора начата',

--- a/wikiweaver.react/src/pages/AdminPage.tsx
+++ b/wikiweaver.react/src/pages/AdminPage.tsx
@@ -17,6 +17,7 @@ import {
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import {
   checkAiConnection,
   cleanupDemoData,
@@ -53,6 +54,7 @@ const getInitialUiMode = (): ParagraphUiMode => {
 
 const AdminPage: React.FC = () => {
   const t = locale.adminPage;
+  const navigate = useNavigate();
   const confirmationPhrase = t.cleanupConfirmationPhrase;
   const queryClient = useQueryClient();
   const [messageApi, contextHolder] = message.useMessage();
@@ -469,6 +471,18 @@ const AdminPage: React.FC = () => {
                   },
                 ]}
               />
+            ),
+          },
+          {
+            key: 'create-article',
+            label: t.createArticleTab,
+            children: (
+              <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+                <Alert type="info" showIcon message={t.createArticleTitle} description={t.createArticleDescription} />
+                <Button type="primary" onClick={() => navigate('/article/new')}>
+                  {t.createArticleAction}
+                </Button>
+              </Space>
             ),
           },
         ]}

--- a/wikiweaver.react/src/pages/add-article/ParagraphGroupEditor.tsx
+++ b/wikiweaver.react/src/pages/add-article/ParagraphGroupEditor.tsx
@@ -35,6 +35,7 @@ const ParagraphGroupEditor: React.FC<ParagraphGroupEditorProps> = ({
       <Radio.Group
         value={group.alternatives.find((alternative) => alternative.isDefault)?.localId}
         onChange={(event) => onSetDefault(group.order, event.target.value)}
+        style={{ width: '100%' }}
       >
         <Space direction="vertical" size="middle" style={{ width: '100%' }}>
           {group.alternatives.map((alternative, index) => (


### PR DESCRIPTION
### Motivation
- Перенести доступ к созданию новой статьи в админ-панель как отдельную вкладку рядом с «Данные» и «Настройки» для более логичного расположения админских действий.
- Увеличить ширину поля ввода версии абзаца, чтобы редактор занимал максимально доступное пространство страницы и улучшить удобство редактирования.

### Description
- Добавлена вкладка `create-article` в `wikiweaver.react/src/pages/AdminPage.tsx` с информацией и кнопкой, ведущей на `/article/new`.
- Удалён пункт «Добавить статью» из верхнего меню в `wikiweaver.react/src/layouts/MainLayout.tsx` и убраны связанные стили/правила в `wikiweaver.react/src/layouts/MainLayout.module.css`.
- Принудительно растянул контейнер с вариантами абзаца в `wikiweaver.react/src/pages/add-article/ParagraphGroupEditor.tsx` (`Radio.Group` получил `style={{ width: '100%' }}`), что позволяет `SimpleMarkdownEditor` занимать всю доступную ширину контента.
- Добавлены локализационные строки для новой вкладки и CTA в `wikiweaver.react/src/localization/ru.ts`.

### Testing
- Запущен линтер командой `npm run lint` и проверка успешно завершилась.
- Собрана фронтенд-часть командой `npm run build` и сборка прошла успешно.
- Выполнен автоматизированный UI-скрипт (Playwright), который открыл админ-панель и сделал скриншот вкладки «Создание статьи», проверка прошла успешно and артефакт сохранён.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af0b527f4832da9dd40a09f71f0d1)