### PR TITLE
fix: increase AI request timeout to prevent errors on large texts

### DIFF
--- a/WikiWeaver.Application/Services/AdminService.cs
+++ b/WikiWeaver.Application/Services/AdminService.cs
@@ -187,6 +187,7 @@ namespace WikiWeaver.Application.Services
             };
 
             var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(110);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", settings.ApiKey);
 
             var endpoint = BuildChatCompletionsEndpoint(settings.BaseUrl);

--- a/wikiweaver.react/src/services/adminService.ts
+++ b/wikiweaver.react/src/services/adminService.ts
@@ -44,7 +44,7 @@ export const updateAiProviderSettings = async (payload: UpdateAiProviderSettings
 };
 
 export const styleMarkdownWithAi = async (payload: AiStyleRequestDto): Promise<AiStyleResponseDto> => {
-  const response = await apiClient.post<AiStyleResponseDto>('/admin/ai-style', payload);
+  const response = await apiClient.post<AiStyleResponseDto>('/admin/ai-style', payload, { timeout: 120_000 });
   return response.data;
 };
 


### PR DESCRIPTION
Frontend Axios timeout overridden to 120s for AI styling requests only; backend HttpClient timeout set to 110s to ensure clean error handling.